### PR TITLE
Use || not_found pattern for carousel lookup

### DIFF
--- a/app/controllers/organisation_events.rb
+++ b/app/controllers/organisation_events.rb
@@ -35,7 +35,7 @@ Dandelion::App.controller do
       @events = if params[:carousel_id] == 'featured'
                   @events.and(featured: true)
                 else
-                  carousel = Carousel.find(params[:carousel_id])
+                  carousel = Carousel.find(params[:carousel_id]) || not_found
                   @events.and(:id.in => EventTagship.and(:event_tag_id.in => carousel.event_tags.pluck(:id)).pluck(:event_id))
                 end
     end
@@ -175,7 +175,7 @@ Dandelion::App.controller do
       @events = if params[:carousel_id] == 'featured'
                   @events.and(featured: true)
                 else
-                  carousel = Carousel.find(params[:carousel_id])
+                  carousel = Carousel.find(params[:carousel_id]) || not_found
                   @events.and(:id.in => EventTagship.and(:event_tag_id.in => carousel.event_tags.pluck(:id)).pluck(:event_id))
                 end
     end


### PR DESCRIPTION
Use || not_found pattern instead of nil checks for carousel lookup in organisation_events.rb

Follows the same pattern used throughout the codebase and returns a 404 response when no carousel is found instead of a NoMethodError.

Fixes #46

Generated with [Claude Code](https://claude.ai/code)