### PR TITLE
Implement caching for slow process

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -116,7 +116,11 @@ module Dandelion
       if current_account
         # signed in
         if request.xhr?
-          partial :newsfeed, locals: { notifications: current_account.network_notifications.order('created_at desc').page(params[:page]), include_circle_name: true }
+          seen = current_account.seen_intro_tour ? 1 : 0
+          cp(:newsfeed,
+             locals: { notifications: current_account.network_notifications.order('created_at desc').page(params[:page]), include_circle_name: true },
+             key: "/newsfeed?account_id=#{current_account.id}&page=#{params[:page] || 1}&seen_intro=#{seen}",
+             expires: 1.minute.from_now)
         else
           @body_class = 'greyed'
           erb :home_signed_in

--- a/models/concerns/account_associations.rb
+++ b/models/concerns/account_associations.rb
@@ -156,21 +156,20 @@ module AccountAssociations
   end
 
   def network_notifications
+    gathering_ids = memberships.pluck(:gathering_id)
+    account_ids = [id] + follows_as_follower.pluck(:followee_id)
+    activity_ids = activityships.pluck(:activity_id)
+    local_group_ids = local_groupships.pluck(:local_group_id)
+    organisation_ids = organisationships.pluck(:organisation_id)
+    organisation_monthly_donor_ids = organisationships.and(:monthly_donation_method.ne => nil).pluck(:organisation_id)
+
     Notification.all.or(
-      { :circle_type => 'Gathering', :circle_id.in => memberships.pluck(:gathering_id) },
-      { :circle_type => 'Account', :circle_id.in => [id] + network.pluck(:id) },
-      { :circle_type => 'Activity', :circle_id.in => activities_following.pluck(:id) },
-      { :circle_type => 'LocalGroup', :circle_id.in => local_groups_following.pluck(:id) },
-      {
-        :circle_type => 'Organisation',
-        :circle_id.in => organisations_following.pluck(:id),
-        :type.ne => 'commented'
-      },
-      {
-        :circle_type => 'Organisation',
-        :circle_id.in => organisations_monthly_donor.pluck(:id),
-        :type => 'commented'
-      }
+      { :circle_type => 'Gathering', :circle_id.in => gathering_ids },
+      { :circle_type => 'Account', :circle_id.in => account_ids },
+      { :circle_type => 'Activity', :circle_id.in => activity_ids },
+      { :circle_type => 'LocalGroup', :circle_id.in => local_group_ids },
+      { :circle_type => 'Organisation', :circle_id.in => organisation_ids, :type.ne => 'commented' },
+      { :circle_type => 'Organisation', :circle_id.in => organisation_monthly_donor_ids, :type => 'commented' }
     )
   end
 


### PR DESCRIPTION
Add fragment caching to the XHR newsfeed and optimize `network_notifications` query to improve performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6e36a7d-8de1-4c62-a8c8-c80db6ee5cd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6e36a7d-8de1-4c62-a8c8-c80db6ee5cd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

