### PR TITLE
Add playful hover animation to event cards

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -874,7 +874,23 @@ figure.image,
 }
 
 .row.block.no-gutters.align-items-stretch {
-  margin: 0
+  margin: 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.row.block.no-gutters.align-items-stretch:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row.block.no-gutters.align-items-stretch {
+    transition: none;
+  }
+
+  .row.block.no-gutters.align-items-stretch:hover {
+    transform: none;
+  }
 }
 
 @media(min-width: 992px) {


### PR DESCRIPTION
## Summary
Event cards now gently lift and cast a shadow on hover, creating a more interactive and delightful user experience. This subtle animation appears throughout the app wherever event cards are displayed.

## Test plan
- [ ] Hover over event cards on the homepage
- [ ] Hover over event cards in search results and carousels
- [ ] Verify animation is smooth and not distracting
- [ ] Test on mobile to ensure no layout shifts
- [ ] Check that motion is disabled for users with `prefers-reduced-motion` enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)