### PR TITLE
Outstanding GitHub issue

### DIFF
--- a/lib/dandelion_bank.rb
+++ b/lib/dandelion_bank.rb
@@ -10,7 +10,14 @@ class DandelionBank < Money::Bank::VariableExchange
 
   def get_rate(iso_from, iso_to, *)
     update_rates if rates_expired?
-    super
+    rate = super
+    return rate if rate
+
+    from_usd = super('USD', iso_to)
+    to_usd = super(iso_from, 'USD')
+    return from_usd * to_usd if from_usd && to_usd
+
+    nil
   end
 
   def update_rates


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add intermediate USD conversion fallback in `DandelionBank#get_rate` to prevent `UnknownRate` errors for missing direct currency conversions.

The `Money::Bank::UnknownRate` error occurred when a direct conversion rate (e.g., GBP to ETH) was not available in the rate store. This PR modifies `DandelionBank#get_rate` to first attempt a direct lookup, and if that fails, it tries to compute the rate via USD (e.g., GBP to USD then USD to ETH) before returning nil. This directly addresses issue #172.

---
<p><a href="https://cursor.com/agents/bc-677e8cd3-a687-4758-83ff-6d74c9c6cd5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677e8cd3-a687-4758-83ff-6d74c9c6cd5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->