### PR TITLE
Ignore vendor/bundle in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tmp/**/*
 bin/*
 vendor/gems/*
 !vendor/gems/cache/
+vendor/bundle/
 .sass-cache/*
 nbproject
 .env


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `vendor/bundle/` to `.gitignore` so local Bundler `--path vendor/bundle` installs do not show up as untracked noise or get committed by mistake.

## Context

The workspace had an untracked `vendor/` tree from a path-based bundle install; gem sources belong in `Gemfile.lock` / CI, not in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10c4cbcb-a900-4487-b41e-d0f635ca938c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10c4cbcb-a900-4487-b41e-d0f635ca938c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

