### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ The Cursor image installs Ruby, Bundler, Foreman, MongoDB, Chromium, and ImageMa
 - Run `foreman start -e .env web` to start the web process
 - Login with `SEED_ACCOUNT_EMAIL` and `SEED_ACCOUNT_PASSWORD` in `.env`
 
+## Cursor Cloud specific instructions
+
+- **Redis**: Must be running (`redis-server --daemonize yes`) before starting the web server. It's used by `Rack::Attack` for rate limiting and by `map_helper.rb` for geocode caching.
+- **MongoDB**: Must be started before seeding or running the web server. Use `bash .cursor/start-services.sh` or `mongod --fork --logpath /tmp/mongod.log --dbpath /data/db --bind_ip 127.0.0.1`.
+- **Google API errors during `db:seed`** are expected and harmless when no `GOOGLE_MAPS_API_KEY` is set — geocoding simply fails silently.
+- **Rubocop**: The codebase has pre-existing offenses (173 as of setup). Run `foreman run -e .env bundle exec rubocop` to lint.
+- **Test a single file**: `env -u BUNDLE_PATH foreman run -e .env.test bundle exec ruby -I test test/<name>_test.rb` — tests start their own Puma on port 8020.
+- **Chromium** is needed for Capybara/Cuprite integration tests. Ensure `BROWSER_PATH` points to the chromium binary.
+
 ## Documentation
 
 You can find documentation at app/views/docs/md. Keep it up to date.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious setup/run caveats for future Cloud Agents:

- Redis must be running for `Rack::Attack` rate limiting and geocode caching
- MongoDB startup dependency for seeding and web server
- Expected Google API errors during `db:seed` (harmless without API key)
- Rubocop and single-test-file command references
- Chromium requirement for Capybara/Cuprite integration tests

### Demo

[dandelion_login_and_events_demo.mp4](https://cursor.com/agents/bc-e7f9cd9d-33e0-452b-a7e2-d4e2e49d29b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdandelion_login_and_events_demo.mp4)

Development environment fully working — logged in as seed user and browsed events.

[Logged in dashboard](https://cursor.com/agents/bc-e7f9cd9d-33e0-452b-a7e2-d4e2e49d29b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogged_in_dashboard.webp)
[Events page](https://cursor.com/agents/bc-e7f9cd9d-33e0-452b-a7e2-d4e2e49d29b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevents_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7f9cd9d-33e0-452b-a7e2-d4e2e49d29b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7f9cd9d-33e0-452b-a7e2-d4e2e49d29b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

