### PR TITLE
Push supported event filters into Atlas Search

### DIFF
--- a/models/concerns/searchable.rb
+++ b/models/concerns/searchable.rb
@@ -40,9 +40,15 @@ module Searchable
         selector = scope.selector
 
         selector.each do |field, value|
-          # Skip top-level MongoDB operators like $or, $and, etc.
+          # Push simple boolean combinations into Atlas Search when every branch has
+          # equivalent Search semantics. Unsupported branches remain in $match.
           if field.to_s.start_with?('$')
-            remaining_selector[field] = value
+            search_filter = atlas_search_filter_for_selector({ field => value }) unless vector_weight&.positive?
+            if search_filter
+              search_filters << search_filter
+            else
+              remaining_selector[field] = value
+            end
           # Skip null checks - Atlas Search equals filter doesn't handle null properly
           # Move them to $match stage instead where MongoDB can properly distinguish
           # between missing fields and fields explicitly set to null
@@ -232,6 +238,66 @@ module Searchable
       return [query] unless query.match?(APOSTROPHE_VARIANTS)
 
       ([query] + APOSTROPHES.map { |ch| query.gsub(APOSTROPHE_VARIANTS, ch) }).uniq
+    end
+
+    def atlas_search_filter_for_selector(selector)
+      return nil unless selector.is_a?(Hash) && selector.any?
+
+      filters = selector.map do |field, value|
+        atlas_search_filter_for_selector_entry(field, value)
+      end
+      return nil if filters.any?(&:nil?)
+
+      filters.length == 1 ? filters.first : { compound: { filter: filters } }
+    end
+
+    def atlas_search_filter_for_selector_entry(field, value)
+      case field.to_s
+      when '$and'
+        atlas_search_compound_filter(value, :filter)
+      when '$or'
+        atlas_search_compound_filter(value, :should)
+      else
+        atlas_search_leaf_filter(field, value)
+      end
+    end
+
+    def atlas_search_compound_filter(branches, clause)
+      return nil unless branches.is_a?(Array) && branches.any?
+
+      filters = branches.map { |branch| atlas_search_filter_for_selector(branch) }
+      return nil if filters.any?(&:nil?)
+
+      compound = { clause => filters }
+      compound[:minimumShouldMatch] = 1 if clause == :should
+      { compound: compound }
+    end
+
+    def atlas_search_leaf_filter(field, value)
+      return nil if value.nil? || field.to_s.start_with?('$')
+
+      if value.is_a?(Hash)
+        atlas_search_range_filter(field, value)
+      else
+        { equals: { path: field.to_s, value: value } }
+      end
+    end
+
+    def atlas_search_range_filter(field, value)
+      return nil if value.empty?
+
+      range_values = {}
+      value.each do |operator, operand|
+        return nil unless %w[$gt $gte $lt $lte].include?(operator.to_s)
+
+        range_values[operator.to_s.delete_prefix('$').to_sym] = operand
+      end
+
+      lower_bound = range_values[:gt] || range_values[:gte]
+      upper_bound = range_values[:lt] || range_values[:lte]
+      return nil if lower_bound && upper_bound && lower_bound >= upper_bound
+
+      { range: { path: field.to_s }.merge(range_values) }
     end
   end
 end

--- a/test/searchable_filter_translation_test.rb
+++ b/test/searchable_filter_translation_test.rb
@@ -1,0 +1,109 @@
+require File.expand_path("#{File.dirname(__FILE__)}/test_config.rb")
+
+class SearchableFilterTranslationTest < ActiveSupport::TestCase
+  class CapturingCollection
+    attr_reader :pipelines
+
+    def initialize
+      @pipelines = []
+    end
+
+    def aggregate(pipeline, **_kwargs)
+      @pipelines << pipeline
+      []
+    end
+  end
+
+  test 'pushes supported organisation event filters into atlas search' do
+    collection = CapturingCollection.new
+    organisation_id = BSON::ObjectId.new
+    from = Time.utc(2026, 7, 4, 23)
+    scope = Event.unscoped
+                 .or({ organisation_id: organisation_id }, { cohosts_ids_cache: organisation_id })
+                 .and(deleted_at: nil)
+                 .and(secret: false)
+                 .future_current_evergreen(from)
+
+    Event.stub(:collection, collection) do
+      Event.search('Sound', scope, regex_search: false)
+    end
+
+    filter = search_filter_for(collection.pipelines.first)
+    suffix_match = suffix_match_for(collection.pipelines.first)
+
+    assert_includes equals_filters(filter), ['organisation_id', organisation_id]
+    assert_includes equals_filters(filter), ['cohosts_ids_cache', organisation_id]
+    assert_includes equals_filters(filter), ['secret', false]
+    assert_includes range_filters(filter), ['start_time', :gte, from]
+    assert_includes range_filters(filter), ['end_time', :gte, from]
+    assert_includes equals_filters(filter), ['show_after_start_time', true]
+    assert_includes equals_filters(filter), ['evergreen', true]
+
+    refute suffix_match.keys.map(&:to_s).include?('$or')
+    assert_equal({ 'deleted_at' => nil }, stringify_keys(suffix_match))
+  end
+
+  test 'leaves unsupported or branch in post search match' do
+    collection = CapturingCollection.new
+    organisation_id = BSON::ObjectId.new
+    scope = Event.unscoped.or({ organisation_id: organisation_id }, { deleted_at: nil })
+
+    Event.stub(:collection, collection) do
+      Event.search('Sound', scope, regex_search: false)
+    end
+
+    filter = search_filter_for(collection.pipelines.first)
+    suffix_match = suffix_match_for(collection.pipelines.first)
+
+    refute_includes equals_filters(filter), ['organisation_id', organisation_id]
+    assert suffix_match.keys.map(&:to_s).include?('$or')
+  end
+
+  private
+
+  def search_filter_for(pipeline)
+    pipeline.first.fetch(:"$search").fetch(:compound).fetch(:filter)
+  end
+
+  def suffix_match_for(pipeline)
+    pipeline.find { |stage| stage.key?(:"$match") }.fetch(:"$match")
+  end
+
+  def equals_filters(node)
+    case node
+    when Array
+      node.flat_map { |item| equals_filters(item) }
+    when Hash
+      if node[:equals]
+        [[node[:equals][:path], node[:equals][:value]]]
+      elsif node[:compound]
+        equals_filters(node[:compound][:filter]) + equals_filters(node[:compound][:should])
+      else
+        []
+      end
+    else
+      []
+    end
+  end
+
+  def range_filters(node)
+    case node
+    when Array
+      node.flat_map { |item| range_filters(item) }
+    when Hash
+      if node[:range]
+        node[:range].except(:path).map { |operator, value| [node[:range][:path], operator, value] }
+      elsif node[:compound]
+        range_filters(node[:compound][:filter]) + range_filters(node[:compound][:should])
+      else
+        []
+      end
+    else
+      []
+    end
+  end
+
+  def stringify_keys(hash)
+    hash.transform_keys(&:to_s)
+  end
+end

--- a/test/searchable_filter_translation_test.rb
+++ b/test/searchable_filter_translation_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path("#{File.dirname(__FILE__)}/test_config.rb")
 
 class SearchableFilterTranslationTest < ActiveSupport::TestCase
+  include Capybara::DSL
+
   class CapturingCollection
     attr_reader :pipelines
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Pushes safely translatable `$and`/`$or` selector branches into Atlas Search `compound.filter`.
- Keeps unsupported selectors, including `nil` checks, in the existing post-search `$match` fallback.
- Adds focused pipeline-shape tests for organisation event filters and unsupported branch fallback.

### Validation
- `ruby -c models/concerns/searchable.rb && ruby -c test/searchable_filter_translation_test.rb`
- `foreman run -e .env.test bundle exec ruby -I test test/searchable_filter_translation_test.rb`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-184b15fb-ec7c-431f-8b20-b47af717df2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-184b15fb-ec7c-431f-8b20-b47af717df2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

