### PR TITLE
Fix NoMethodError when saving event with stale ticket type nested attributes

### DIFF
--- a/models/concerns/event_associations.rb
+++ b/models/concerns/event_associations.rb
@@ -40,20 +40,10 @@ module EventAssociations
     has_many :notifications, as: :notifiable, dependent: :destroy
 
     has_many :ticket_types, dependent: :destroy
-    accepts_nested_attributes_for :ticket_types, allow_destroy: true, reject_if: lambda { |attributes|
-      return true if %w[name description price quantity].all? { |f| attributes[f].nil? }
-      return true if attributes[:id].present? && attributes[:_destroy].blank? && !TicketType.exists?(attributes[:id])
-
-      false
-    }
+    accepts_nested_attributes_for :ticket_types, allow_destroy: true, reject_if: :reject_ticket_type_nested_attributes?
 
     has_many :ticket_groups, dependent: :destroy
-    accepts_nested_attributes_for :ticket_groups, allow_destroy: true, reject_if: lambda { |attributes|
-      return true if %w[name capacity].all? { |f| attributes[f].nil? }
-      return true if attributes[:id].present? && attributes[:_destroy].blank? && !TicketGroup.exists?(attributes[:id])
-
-      false
-    }
+    accepts_nested_attributes_for :ticket_groups, allow_destroy: true, reject_if: :reject_ticket_group_nested_attributes?
 
     has_many :tickets, dependent: :destroy
     has_many :donations, dependent: :nullify
@@ -142,5 +132,19 @@ module EventAssociations
     a = [account, revenue_sharer, coordinator].compact
     a += event_facilitators
     a.uniq
+  end
+
+  def reject_ticket_type_nested_attributes?(attributes)
+    return true if %w[name description price quantity].all? { |f| attributes[f].nil? }
+    return true if attributes[:id].present? && !ticket_types.where(_id: attributes[:id]).exists?
+
+    false
+  end
+
+  def reject_ticket_group_nested_attributes?(attributes)
+    return true if %w[name capacity].all? { |f| attributes[f].nil? }
+    return true if attributes[:id].present? && !ticket_groups.where(_id: attributes[:id]).exists?
+
+    false
   end
 end

--- a/test/event_nested_attributes_test.rb
+++ b/test/event_nested_attributes_test.rb
@@ -1,0 +1,64 @@
+require 'test_config'
+
+class EventNestedAttributesTest < ActiveSupport::TestCase
+  include Capybara::DSL
+
+  setup do
+    create_full_event_hierarchy
+    @ticket_type = FactoryBot.create(:ticket_type, event: @event)
+    @event.reload
+  end
+
+  def test_destroying_already_deleted_ticket_type_does_not_raise
+    ticket_type_id = @ticket_type.id.to_s
+    @ticket_type.destroy
+
+    assert_nothing_raised do
+      @event.update_attributes(
+        ticket_types_attributes: {
+          '0' => {
+            'id' => ticket_type_id,
+            '_destroy' => '1',
+            'name' => 'General admission',
+            'quantity' => 10
+          }
+        }
+      )
+    end
+  end
+
+  def test_updating_already_deleted_ticket_type_does_not_raise
+    ticket_type_id = @ticket_type.id.to_s
+    @ticket_type.destroy
+
+    assert_nothing_raised do
+      @event.update_attributes(
+        ticket_types_attributes: {
+          '0' => {
+            'id' => ticket_type_id,
+            'name' => 'General admission',
+            'quantity' => 10,
+            'order' => 0
+          }
+        }
+      )
+    end
+  end
+
+  def test_destroying_existing_ticket_type_still_works
+    ticket_type_id = @ticket_type.id.to_s
+
+    assert @event.update_attributes(
+      ticket_types_attributes: {
+        '0' => {
+          'id' => ticket_type_id,
+          '_destroy' => '1',
+          'name' => @ticket_type.name,
+          'quantity' => @ticket_type.quantity
+        }
+      }
+    )
+
+    assert_nil TicketType.find(ticket_type_id)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DANDELION-2X

## Problem

Production error on `POST /e/:slug/edit`:

```
NoMethodError: undefined method 'update_attributes' for nil
```

This occurred when saving an event whose form included nested `ticket_types_attributes` (or `ticket_groups_attributes`) referencing a record no longer associated with the event — commonly when marking a ticket type for deletion (`_destroy=1`) while the form still submits the hidden field values from the removed row.

The existing `reject_if` guard only skipped invalid IDs when `_destroy` was blank, so destroy submissions for already-deleted records bypassed the guard. Mongoid's reparenting path then called `update_attributes` on `nil` (because `Mongoid.raise_not_found_error = false`).

## Fix

- Reject nested ticket type / ticket group attributes when the submitted `id` is not present on the parent event's association
- Use symbol-based `reject_if` methods so the check can use the event's loaded associations

## Tests

Added `test/event_nested_attributes_test.rb` covering:
- Destroying an already-deleted ticket type (no error)
- Updating an already-deleted ticket type (no error)
- Destroying an existing ticket type still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-802c0c91-a38f-462b-8aa7-efe3785aa983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-802c0c91-a38f-462b-8aa7-efe3785aa983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

