### PR TITLE
Revert last two commits (variable price tickets + mapplication notifications)

### DIFF
--- a/app/helpers/purchase_helper.rb
+++ b/app/helpers/purchase_helper.rb
@@ -68,18 +68,12 @@ Dandelion::App.helpers do
 
     ticket_form[:quantities].each do |ticket_type_id, quantity|
       ticket_type = @event.ticket_types.find(ticket_type_id) || not_found
-      price = if ticket_type.range || ticket_type.price.nil?
-                submitted_price = Float(ticket_form[:prices]&.[](ticket_type_id))
-                raise ArgumentError, 'ticket price must be finite' unless submitted_price.finite?
-
-                ticket_type.range ? submitted_price.clamp(*ticket_type.range) : submitted_price
-              end
       quantity.to_i.times do
         order.tickets.create!(
           event: @event,
           account: @account,
           ticket_type: ticket_type,
-          price: price
+          price: (ticket_form[:prices][ticket_type_id] if ticket_type.range || !ticket_type.price)
         )
       end
     end

--- a/models/mapplication.rb
+++ b/models/mapplication.rb
@@ -38,7 +38,7 @@ class Mapplication
   end
 
   after_destroy do
-    account.notifications_as_notifiable.create! circle: gathering, type: 'mapplication_removed' if gathering && !gathering.flagged_for_destroy? && !prevent_notifications
+    account.notifications_as_notifiable.create! circle: gathering, type: 'mapplication_removed' unless prevent_notifications
   end
 
   def self.pending

--- a/models/ticket.rb
+++ b/models/ticket.rb
@@ -52,18 +52,9 @@ class Ticket
     self.id_string = id.to_s if id && !id_string
 
     self.price = ticket_type.price if !price && !complimentary && ticket_type && ticket_type.price
-    variable_price_ticket = ticket_type && (ticket_type.range || ticket_type.price.nil?)
-    if variable_price_ticket && !complimentary
-      if !price&.finite?
-        errors.add(:price, 'must be a number')
-      elsif ticket_type.range
-        self.price = price.clamp(*ticket_type.range)
-      elsif price < 1
-        errors.add(:price, 'is too low')
-      end
-    end
+    errors.add(:price, 'is too low') if price && ticket_type && ticket_type.range_min && price < ticket_type.range_min
 
-    self.payment_completed = true if complimentary || price == 0 || (price.nil? && !variable_price_ticket)
+    self.payment_completed = true if complimentary || price.nil? || price == 0
 
     self.original_ticket_type_name = ticket_type.name if ticket_type && !original_ticket_type_name
     self.currency = (order.try(:currency) || event.try(:currency)) unless currency


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Temporarily reverts the last two commits on `master` after a regression from the variable-price ticket validation change.

## Reverted

1. `c6521342` — fix variable price ticket validation and range clamping
2. `86c13aec` — Prevent notification creation when gathering is nil or being destroyed

## Why

The variable-price ticket change appears to have broken purchase/payment behavior. Reverting both for now restores the prior working state; we can reintroduce the notification guard separately if needed.

## Files

- `models/ticket.rb`
- `app/helpers/purchase_helper.rb`
- `models/mapplication.rb`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d95ab923-b861-4c75-9166-e01a05e85ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d95ab923-b861-4c75-9166-e01a05e85ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

