### PR TITLE
✨ GoCardless instalment schedules for event tickets

### DIFF
--- a/app/assets/javascripts/event_payment_handlers.js
+++ b/app/assets/javascripts/event_payment_handlers.js
@@ -20,6 +20,10 @@ function eventPaymentHandlers (config) {
       window.location = data.gocardless_billing_request_flow['authorisation_url']
     },
 
+    gocardless_instalments: function (data) {
+      window.location = data.gocardless_billing_request_flow['authorisation_url']
+    },
+
     opencollective: function (data) {
       window.location = 'https://opencollective.com/' + config.organisationOcSlug + '/events/' + config.ocSlug + '/donate?interval=oneTime&amount=' + data.value + '&tags=' + data.oc_secret + '&redirect=' + encodeURIComponent(config.eventUrl + '?success=true&order_id=' + data.order_id)
     },

--- a/app/assets/javascripts/purchase.js
+++ b/app/assets/javascripts/purchase.js
@@ -199,6 +199,7 @@ $(function () {
     $('#balance').val((+b).toFixed(2))
     const $rsvp = $('#details form button[data-payment-method=rsvp]')
     const $stripe = $('#details form button[data-payment-method=stripe]')
+    const $gocardlessInstalments = $('#details form button[data-payment-method=gocardless_instalments]')
     const $paid = $('#details form button[data-payment-method]').not($rsvp)
     const $firstPaidButton = $('#details form button[data-payment-method]').eq(1)
 
@@ -211,11 +212,16 @@ $(function () {
     } else if (b > 0) {
       $('#balance').val((+b).toFixed(2))
       let via_card
-      if (config.gocardless || config.ocSlug || config.evmAddress) { via_card = ' via card' } else { via_card = '' }
+      if (config.gocardless || config.gocardlessInstalments || config.ocSlug || config.evmAddress) { via_card = ' via card' } else { via_card = '' }
       $firstPaidButton.removeClass('btn-outline-primary').addClass('btn-primary')
       $rsvp.hide()
       $paid.show()
       $stripe.find('span').text('Pay ' + config.currencySymbol + (+b).toFixed(2) + via_card)
+      if (config.gocardlessInstalmentCount) {
+        const n = config.gocardlessInstalmentCount
+        const each = ((+b) / n).toFixed(2)
+        $gocardlessInstalments.find('span').text('Pay ' + n + '× ' + config.currencySymbol + each + ' via Direct Debit')
+      }
     }
 
     $('input[type=hidden][name=payment_method]').prop('disabled', true)

--- a/app/controllers/events.rb
+++ b/app/controllers/events.rb
@@ -175,13 +175,18 @@ Dandelion::App.controller do
     halt 200 if request.head?
 
     @order = Order.find(params[:order_id]) || not_found if params[:order_id]
-    if params[:payment_request_id]
-      gocardless_order = @event.orders.find_by(gocardless_payment_request_id: params[:payment_request_id])
+    if params[:payment_request_id] || params[:billing_request_id]
+      gocardless_order = if params[:billing_request_id]
+                          @event.orders.find_by(gocardless_billing_request_id: params[:billing_request_id])
+                        else
+                          @event.orders.find_by(gocardless_payment_request_id: params[:payment_request_id])
+                        end
       if gocardless_order && !params[:cancelled]
         if gocardless_order.payment_completed?
           @order = gocardless_order
         else
           @gocardless_order = gocardless_order
+          gocardless_order.create_gocardless_instalment_schedule! if gocardless_order.gocardless_instalments? && gocardless_order.gocardless_instalment_schedule_id.blank?
         end
       end
     end

--- a/app/controllers/orders.rb
+++ b/app/controllers/orders.rb
@@ -26,7 +26,12 @@ Dandelion::App.controller do
     @order = @event.orders.find(params[:order_id]) || not_found
     @event.organisation.check_evm_account if @order.evm_secret && @event.organisation.evm_address
     @event.check_oc_event if @order.oc_secret && @event.oc_slug
-    { id: @order.id.to_s, payment_completed: @order.payment_completed }.to_json
+    {
+      id: @order.id.to_s,
+      payment_completed: @order.payment_completed,
+      instalment_schedule_created: @order.gocardless_instalment_schedule_id.present?,
+      gocardless_instalments: @order.gocardless_instalments?
+    }.to_json
   end
 
   get '/events/:id/orders/:order_id/ticketholders/:ticket_id/name' do

--- a/app/controllers/webhooks.rb
+++ b/app/controllers/webhooks.rb
@@ -50,22 +50,55 @@ Dandelion::App.controller do
     events.each do |event|
       if event.resource_type == 'subscriptions' && event.action == 'created'
         @organisation.gocardless_subscribe(subscription_id: event.links.subscription)
+      elsif event.resource_type == 'billing_requests' && event.action == 'fulfilled'
+        billing_request_id = event.links.billing_request
+        next unless billing_request_id
+
+        order = @organisation.orders.find_by(gocardless_billing_request_id: billing_request_id, payment_completed: false)
+        order&.create_gocardless_instalment_schedule!
+      elsif event.resource_type == 'instalment_schedules' && event.action == 'completed'
+        schedule_id = event.links.instalment_schedule
+        next unless schedule_id
+
+        if (order = @organisation.orders.find_by(gocardless_instalment_schedule_id: schedule_id, payment_completed: false))
+          order.complete_gocardless_instalments!
+        elsif (order = Order.deleted.find_by(gocardless_instalment_schedule_id: schedule_id, payment_completed: false))
+          begin
+            order.tickets.deleted.each(&:restore)
+            order.donations.deleted.each(&:restore)
+            order.restore
+            order.set(restored: true)
+            order.complete_gocardless_instalments!
+          rescue StandardError => e
+            ErrorReporting.capture_exception(e, context: { gocardless_event_id: event.id })
+          end
+        end
       elsif event.resource_type == 'payments' && event.action == 'confirmed'
         payment_request_id = event.to_h.dig('links', 'payment_request')
         payment_id = event.links.payment
-        next unless payment_request_id
+        instalment_schedule_id = event.links.instalment_schedule
 
-        if (@order = @organisation.orders.find_by(gocardless_payment_request_id: payment_request_id, payment_completed: false))
-          @order.persist_gocardless_payment_id(payment_id)
-          @order.payment_completed!
-          @order.send_tickets
-          @order.create_order_notification
-        elsif (@order = Order.deleted.find_by(gocardless_payment_request_id: payment_request_id, payment_completed: false))
-          begin
+        if instalment_schedule_id && (order = @organisation.orders.find_by(gocardless_instalment_schedule_id: instalment_schedule_id, payment_completed: false))
+          amount_major = begin
+            client = GoCardlessPro::Client.new(access_token: @organisation.gocardless_access_token)
+            client.payments.get(payment_id).amount.to_i / 100.0
+          rescue StandardError
+            0
+          end
+          order.record_gocardless_instalment_payment!(payment_id: payment_id, amount_major: amount_major)
+        elsif payment_request_id
+          if (@order = @organisation.orders.find_by(gocardless_payment_request_id: payment_request_id, payment_completed: false))
             @order.persist_gocardless_payment_id(payment_id)
-            @order.restore_and_complete
-          rescue StandardError => e
-            ErrorReporting.capture_exception(e, context: { gocardless_event_id: event.id })
+            @order.payment_completed!
+            @order.send_tickets
+            @order.create_order_notification
+          elsif (@order = Order.deleted.find_by(gocardless_payment_request_id: payment_request_id, payment_completed: false))
+            begin
+              @order.persist_gocardless_payment_id(payment_id)
+              @order.restore_and_complete
+            rescue StandardError => e
+              ErrorReporting.capture_exception(e, context: { gocardless_event_id: event.id })
+            end
           end
         end
       end

--- a/app/views/docs/md/events.md
+++ b/app/views/docs/md/events.md
@@ -50,9 +50,19 @@ To let your attendees choose how much to pay for a ticket type:
 
 ## Allowing people to pay in instalments
 
-The best solution for this is to enable an instalment payment method on your Stripe account, such as [Klarna](https://docs.stripe.com/payments/klarna) or [Clearpay/Afterpay](https://docs.stripe.com/payments/afterpay-clearpay). Customers will then be able to pay for the purchase in instalments at checkout.
+### GoCardless instalment schedules
 
-Alternatively, you can create a secret ticket type with a quantity equal to the number of instalments and send a link to the attendee. (Make sure you check that they actually end up purchasing all the tickets of this ticket type!)
+If your organisation uses GoCardless, enable **GoCardless instalment schedules** in organisation settings (under Instant Bank Pay via GoCardless) and set how many monthly instalments to offer (2–12).
+
+At checkout, buyers can choose **Pay in instalments**. They set up a Direct Debit mandate once; GoCardless then collects equal monthly payments. Tickets are emailed only when all instalments have cleared.
+
+### Stripe buy now, pay later
+
+Alternatively, enable an instalment payment method on your Stripe account, such as [Klarna](https://docs.stripe.com/payments/klarna) or [Clearpay/Afterpay](https://docs.stripe.com/payments/afterpay-clearpay). Customers pay in instalments at checkout, and you receive the full amount up front — so tickets are sent immediately as with a normal card payment.
+
+### Manual workaround
+
+You can also create a secret ticket type with a quantity equal to the number of instalments and send a link to the attendee. (Make sure you check that they actually end up purchasing all the tickets of this ticket type!)
 
 ## Including sales taxes (VAT/MOMS)
 

--- a/app/views/docs/md/organisations.md
+++ b/app/views/docs/md/organisations.md
@@ -6,6 +6,8 @@ Click Organisations > Create an organisation in the sidebar. Provide the basic d
 
 To accept payments for tickets to events created under the organisation, you must add details for Stripe or another payment processor in the Payments tab of your organisation's settings.
 
+For GoCardless, add an access token and webhook endpoint, then optionally enable Instant Bank Pay and/or instalment schedules. Instalment schedules split ticket orders into equal monthly Direct Debit payments; tickets are emailed only when the full amount has cleared.
+
 ## Analytics
 
 In organisation settings under **Analytics**, you can add a Meta/Facebook Pixel ID (digits only). With marketing cookie consent, Dandelion loads the pixel on organisation and event pages, sends `PageView` and `ViewContent` on event pages, and a single `Purchase` after a successful booking. You can also set a pixel on an individual event; if both are set and different, events are sent to both.

--- a/app/views/events/_orders_table.erb
+++ b/app/views/events/_orders_table.erb
@@ -170,12 +170,16 @@
         <span class="label label-default bg-secondary mr-1">EVM: <%= order.evm_secret %></span>
       <% elsif order.oc_secret %>
         <span class="label label-default bg-secondary mr-1">OC: <%= order.oc_secret.split('dandelion:').last %></span>
+      <% elsif order.gocardless_instalments? %>
+        <span class="label label-default bg-gocardless mr-1">GoCardless instalments<% if order.amount_paid && order.amount_demanded %> (<%= m order.amount_paid, order.currency %>/<%= m order.amount_demanded, order.currency %>)<% end %></span>
       <% elsif order.gocardless_payment_request_id %>
         <span class="label label-default bg-gocardless mr-1">GoCardless</span>
       <% end %>
       <% if order.incomplete? %>
         <% if order.deleted? %>
           <i data-toggle="tooltip" title="Timed out" class="bi bi-exclamation-triangle-fill"></i>
+        <% elsif order.gocardless_instalments? %>
+          <i data-toggle="tooltip" title="Instalment plan in progress. Tickets will be sent when all payments have cleared." class="bi bi-spin bi-arrow-repeat"></i>
         <% else %>
           <i data-toggle="tooltip" title="This person is in the process of completing the order. If they don't complete it soon, the order will be removed." class="bi bi-spin bi-arrow-repeat"></i>
         <% end %>

--- a/app/views/events/_ticket_price.erb
+++ b/app/views/events/_ticket_price.erb
@@ -29,8 +29,16 @@
     <span class="label label-default bg-secondary mr-1">EVM: <%= ticket.order.evm_secret %></span>
   <% elsif ticket.order.oc_secret %>
     <span class="label label-default bg-secondary mr-1">OC: <%= ticket.order.oc_secret.split('dandelion:').last %></span>
+  <% elsif ticket.order.gocardless_instalments? %>
+    <span class="label label-default bg-gocardless mr-1">GoCardless instalments</span>
   <% elsif ticket.order.gocardless_payment_request_id %>
     <span class="label label-default bg-gocardless mr-1">GoCardless</span>
   <% end %>
-  <% if ticket.incomplete? %><i data-toggle="tooltip" title="This person is in the process of completing the order. If they don't complete it soon, the order will be removed." class="bi bi-spin bi-arrow-repeat"></i><% end %>
+  <% if ticket.incomplete? %>
+    <% if ticket.order.gocardless_instalments? %>
+      <i data-toggle="tooltip" title="Instalment plan in progress. Tickets will be sent when all payments have cleared." class="bi bi-spin bi-arrow-repeat"></i>
+    <% else %>
+      <i data-toggle="tooltip" title="This person is in the process of completing the order. If they don't complete it soon, the order will be removed." class="bi bi-spin bi-arrow-repeat"></i>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/events/event.erb
+++ b/app/views/events/event.erb
@@ -44,20 +44,47 @@
       <%= partial :'events/success' %>
     <% elsif @gocardless_order %>
       <div class="card shadow-sm mb-3">
-        <h3 class="card-header bg-primary text-white">Confirming your payment</h3>
-        <div class="card-body readable">
-          <p class="mb-0">We're confirming your payment with GoCardless... <i class="bi bi-spin bi-slash-lg"></i></p>
-        </div>
-      </div>
-      <script>
-        $(function () {
-          setInterval(function () {
-            $.getJSON('/events/<%= @event.id %>/orders/<%= @gocardless_order.id %>/payment_completed', function (data) {
-              if (data.payment_completed) { window.location.reload() }
+        <% if @gocardless_order.gocardless_instalments? %>
+          <h3 class="card-header bg-primary text-white">Setting up your instalment plan</h3>
+          <div class="card-body readable">
+            <% if @gocardless_order.gocardless_instalment_schedule_id %>
+              <p class="mb-0">
+                Your Direct Debit instalment plan is active
+                <% if @gocardless_order.instalment_count && @gocardless_order.amount_demanded %>
+                  (<%= @gocardless_order.instalment_count %>× <%= m (@gocardless_order.amount_demanded / @gocardless_order.instalment_count.to_f), @gocardless_order.currency %> monthly)
+                <% end %>.
+                You'll receive your tickets by email once all payments have cleared.
+              </p>
+            <% else %>
+              <p class="mb-0">We're setting up your GoCardless instalment plan... <i class="bi bi-spin bi-slash-lg"></i></p>
+            <% end %>
+          </div>
+          <% unless @gocardless_order.gocardless_instalment_schedule_id %>
+            <script>
+              $(function () {
+                setInterval(function () {
+                  $.getJSON('/events/<%= @event.id %>/orders/<%= @gocardless_order.id %>/payment_completed', function (data) {
+                    if (data.payment_completed || data.instalment_schedule_created) { window.location.reload() }
+                  })
+                }, 3 * 1000)
+              })
+            </script>
+          <% end %>
+        <% else %>
+          <h3 class="card-header bg-primary text-white">Confirming your payment</h3>
+          <div class="card-body readable">
+            <p class="mb-0">We're confirming your payment with GoCardless... <i class="bi bi-spin bi-slash-lg"></i></p>
+          </div>
+          <script>
+            $(function () {
+              setInterval(function () {
+                $.getJSON('/events/<%= @event.id %>/orders/<%= @gocardless_order.id %>/payment_completed', function (data) {
+                  if (data.payment_completed) { window.location.reload() }
+                })
+              }, 3 * 1000)
             })
-          }, 3 * 1000)
-        })
-      </script>
+          </script>
+        <% end %>
     <% elsif @event_image %>
       <a href="/e/<%=@event.slug%><% if params[:cohost] %>?cohost=<%=params[:cohost]%><% end %>"><%= blurred_image_tag(@event_image, width: @event_image_width, height: @event_image_height, full_size: '1920x1920', md_size: '992x992', css_class: 'w-100 mb-3', id: 'event-image') %></a>
     <% end %>

--- a/app/views/organisations/build.erb
+++ b/app/views/organisations/build.erb
@@ -169,7 +169,7 @@
           </div>
           <div class="card mb-3">
             <div class="card-header text-white bg-primary">
-              <h4 class="my-0">Instant Bank Pay via GoCardless</h4>
+              <h4 class="my-0">GoCardless</h4>
             </div>
             <div class="card-body pb-0">
               <p>
@@ -183,6 +183,8 @@
               <%= f.text_block :gocardless_access_token %>
               <%= f.text_block :gocardless_endpoint_secret %>
               <%= f.check_box_block :gocardless_instant_bank_pay %>
+              <%= f.check_box_block :gocardless_instalments %>
+              <%= f.number_block :gocardless_instalment_count %>
               <%= f.check_box_block :gocardless_subscriptions %>
             </div>
           </div>

--- a/app/views/purchase/_purchase.erb
+++ b/app/views/purchase/_purchase.erb
@@ -224,6 +224,8 @@ end
     stripePk: (@event.organisation.stripe_connect_json ? ENV['STRIPE_PK'] : @event.organisation.stripe_pk),
     stripeAccount: @event.revenue_sharer_organisationship && @event.direct_charges ? @event.revenue_sharer_organisationship.stripe_user_id : @event.organisation.stripe_user_id,
     gocardless: !!(@event.organisation.gocardless_instant_bank_pay && @event.organisation.gocardless_access_token),
+    gocardlessInstalments: !!(@event.organisation.gocardless_instalments && @event.organisation.gocardless_access_token),
+    gocardlessInstalmentCount: (@event.organisation.gocardless_instalments ? (@event.organisation.gocardless_instalment_count || 3) : nil),
     organisationOcSlug: @event.organisation.oc_slug,
     ocSlug: @event.oc_slug,
     evmAddress: @event.organisation.evm_address,

--- a/lib/payment_methods/event_payment_methods.rb
+++ b/lib/payment_methods/event_payment_methods.rb
@@ -62,6 +62,12 @@ EventPaymentMethod.new('gocardless',
                        event_condition: ->(event) { FIAT_CURRENCIES.include?(event.currency) },
                        process: ->(**kwargs) { EventPaymentMethod::GoCardless.call(**kwargs) })
 
+EventPaymentMethod.new('gocardless_instalments',
+                       label: 'Pay in instalments',
+                       org_condition: ->(org) { org.gocardless_instalments && org.gocardless_access_token },
+                       event_condition: ->(event) { FIAT_CURRENCIES.include?(event.currency) },
+                       process: ->(**kwargs) { EventPaymentMethod::GoCardlessInstalments.call(**kwargs) })
+
 EventPaymentMethod.new('opencollective',
                        label: 'Pay with Open Collective',
                        org_condition: lambda(&:oc_slug),

--- a/lib/payment_methods/event_payment_methods/gocardless_instalments.rb
+++ b/lib/payment_methods/event_payment_methods/gocardless_instalments.rb
@@ -1,0 +1,96 @@
+class EventPaymentMethod
+  module GoCardlessInstalments
+    def self.call(order:, event:, **)
+      organisation = event.organisation
+      client = GoCardlessPro::Client.new(access_token: organisation.gocardless_access_token)
+      instalment_count = organisation.gocardless_instalment_count || 3
+      amount_demanded = order.total.round(2)
+
+      billing_request = client.billing_requests.create(
+        params: {
+          mandate_request: {
+            currency: order.currency
+          },
+          metadata: {
+            de_order_id: order.id.to_s,
+            de_event_id: event.id.to_s
+          }
+        }
+      )
+
+      order.update_attributes!(
+        value: amount_demanded,
+        amount_demanded: amount_demanded,
+        amount_paid: 0,
+        instalment_count: instalment_count,
+        gocardless_billing_request_id: billing_request.id
+      )
+
+      return_base = "#{ENV['BASE_URI']}/e/#{event.slug}?billing_request_id=#{billing_request.id}"
+      billing_request_flow = client.billing_request_flows.create(
+        params: {
+          redirect_uri: URI::DEFAULT_PARSER.escape("#{return_base}&success=true"),
+          exit_uri: URI::DEFAULT_PARSER.escape("#{return_base}&cancelled=true"),
+          lock_currency: true,
+          links: { billing_request: billing_request.id }
+        }
+      )
+
+      { gocardless_billing_request_flow: billing_request_flow }.to_json
+    end
+
+    def self.split_amounts_in_pence(total_major, count)
+      total = (BigDecimal(total_major.to_s) * 100).round.to_i
+      base = total / count
+      amounts = Array.new(count, base)
+      amounts[-1] += total - amounts.sum
+      amounts
+    end
+
+    def self.create_schedule_for_order!(order)
+      return if order.gocardless_instalment_schedule_id.present?
+      return unless order.gocardless_billing_request_id.present?
+
+      organisation = order.event.organisation
+      client = GoCardlessPro::Client.new(access_token: organisation.gocardless_access_token)
+      billing_request = client.billing_requests.get(order.gocardless_billing_request_id)
+      mandate_id = billing_request.links.mandate_request_mandate
+      if mandate_id.blank? && billing_request.mandate_request.is_a?(Hash)
+        mandate_id = billing_request.mandate_request.dig('links', 'mandate')
+      end
+      return unless mandate_id
+
+      mandate = client.mandates.get(mandate_id)
+      start_date = mandate.next_possible_charge_date || (Date.today + 3).iso8601
+
+      count = order.instalment_count || organisation.gocardless_instalment_count || 3
+      amounts = split_amounts_in_pence(order.amount_demanded || order.value || order.total, count)
+
+      schedule = client.instalment_schedules.create_with_schedule(
+        params: {
+          name: order.description.truncate(100),
+          currency: order.currency,
+          total_amount: amounts.sum,
+          retry_if_possible: true,
+          metadata: {
+            de_order_id: order.id.to_s,
+            de_event_id: order.event_id.to_s
+          },
+          instalments: {
+            start_date: start_date,
+            interval_unit: 'monthly',
+            interval: 1,
+            amounts: amounts
+          },
+          links: { mandate: mandate_id }
+        }
+      )
+
+      order.set(
+        gocardless_mandate_id: mandate_id,
+        gocardless_instalment_schedule_id: schedule.id
+      )
+      schedule
+    end
+  end
+end

--- a/models/concerns/order_fields.rb
+++ b/models/concerns/order_fields.rb
@@ -14,6 +14,13 @@ module OrderFields
     field :coinbase_checkout_id, type: String
     field :gocardless_payment_request_id, type: String
     field :gocardless_payment_id, type: String
+    field :gocardless_billing_request_id, type: String
+    field :gocardless_mandate_id, type: String
+    field :gocardless_instalment_schedule_id, type: String
+    field :gocardless_payment_ids, type: Array
+    field :amount_demanded, type: Float
+    field :amount_paid, type: Float
+    field :instalment_count, type: Integer
     field :evm_secret, type: String
     field :evm_value, type: BigDecimal
     field :oc_secret, type: String

--- a/models/concerns/organisation_fields.rb
+++ b/models/concerns/organisation_fields.rb
@@ -27,6 +27,8 @@ module OrganisationFields
     field :gocardless_endpoint_secret, type: String
     field :gocardless_filter, type: String
     field :gocardless_instant_bank_pay, type: Mongoid::Boolean
+    field :gocardless_instalments, type: Mongoid::Boolean
+    field :gocardless_instalment_count, type: Integer
     field :gocardless_subscriptions, type: Mongoid::Boolean
     field :patreon_api_key, type: String
     field :mailgun_api_key, type: String
@@ -133,6 +135,8 @@ module OrganisationFields
         gocardless_access_token: 'GoCardless access token',
         gocardless_endpoint_secret: 'GoCardless webhook secret',
         gocardless_instant_bank_pay: 'Enable GoCardless Instant Bank Pay',
+        gocardless_instalments: 'Enable GoCardless instalment schedules',
+        gocardless_instalment_count: 'Number of monthly instalments',
         gocardless_subscriptions: 'Register people with active GoCardless subscriptions as monthly donors',
         patreon_api_key: 'Patreon API key',
         mailgun_api_key: 'Mailgun API key',
@@ -197,6 +201,8 @@ module OrganisationFields
         hide_ticket_revenue: 'Hide ticket revenue in event stats',
         collect_location: 'Request the location of ticket buyers at checkout',
         tax_rate_id: 'Stripe tax rate ID to apply to ticket purchases',
+        gocardless_instalments: 'Offer Direct Debit instalment plans at checkout. Tickets are emailed only when all instalments have cleared.',
+        gocardless_instalment_count: 'How many equal monthly payments to split the order into (2–12). Default is 3.',
         referrer_id: 'Credit someone for referring you to Dandelion',
         minimal_head: 'Custom CSS/JS to include in the &lt;head&gt; when embedding your events page',
         allow_event_submissions: 'When enabled, any signed-in user can submit an event. Submissions are initially visible only to admins, who receive an email notification.'

--- a/models/concerns/organisation_validation.rb
+++ b/models/concerns/organisation_validation.rb
@@ -62,6 +62,12 @@ module OrganisationValidation
       errors.add(:stripe_sk, 'must be present if Stripe public key is present') if stripe_pk && !stripe_sk
 
       errors.add(:gocardless_instant_bank_pay, 'requires GoCardless webhook secret') if gocardless_instant_bank_pay && !gocardless_endpoint_secret
+      errors.add(:gocardless_instalments, 'requires GoCardless access token') if gocardless_instalments && !gocardless_access_token
+      errors.add(:gocardless_instalments, 'requires GoCardless webhook secret') if gocardless_instalments && !gocardless_endpoint_secret
+      if gocardless_instalment_count
+        errors.add(:gocardless_instalment_count, 'must be between 2 and 12') unless gocardless_instalment_count.between?(2, 12)
+      end
+      self.gocardless_instalment_count = 3 if gocardless_instalments && gocardless_instalment_count.nil?
 
       if patreon_api_key.present?
         patreon_host = begin

--- a/models/concerns/refundable.rb
+++ b/models/concerns/refundable.rb
@@ -1,6 +1,6 @@
 module Refundable
   def refundable?
-    session_id || gocardless_payment_id
+    session_id || gocardless_payment_id || (respond_to?(:gocardless_instalment_schedule_id) && gocardless_instalment_schedule_id.present?)
   end
 
   def refund_via_stripe(payment_intent:, on_error:, amount: nil, refund_application_fee: false)

--- a/models/order.rb
+++ b/models/order.rb
@@ -137,12 +137,53 @@ class Order
   end
 
   def persist_gocardless_payment_id(payment_id)
-    return if gocardless_payment_id.present? || payment_id.blank?
+    return if payment_id.blank?
+
+    ids = Array(gocardless_payment_ids).map(&:to_s)
+    unless ids.include?(payment_id.to_s)
+      ids << payment_id.to_s
+      set(gocardless_payment_ids: ids)
+    end
+
+    return if gocardless_payment_id.present?
 
     set(gocardless_payment_id: payment_id)
     tickets.each do |ticket|
       ticket.update_attributes!(gocardless_payment_id: payment_id)
     end
+  end
+
+  def gocardless_instalments?
+    instalment_count.present? || gocardless_billing_request_id.present? || gocardless_instalment_schedule_id.present?
+  end
+
+  def record_gocardless_instalment_payment!(payment_id:, amount_major:)
+    return if payment_id.blank?
+    return if payment_completed?
+
+    ids = Array(gocardless_payment_ids).map(&:to_s)
+    return if ids.include?(payment_id.to_s)
+
+    persist_gocardless_payment_id(payment_id)
+    paid = (amount_paid || 0) + amount_major.to_f
+    set(amount_paid: paid.round(2))
+    complete_gocardless_instalments! if amount_demanded && paid >= amount_demanded
+  end
+
+  def complete_gocardless_instalments!
+    return if payment_completed?
+
+    set(amount_paid: amount_demanded) if amount_demanded && (amount_paid.nil? || amount_paid < amount_demanded)
+    payment_completed!
+    send_tickets
+    create_order_notification
+  end
+
+  def create_gocardless_instalment_schedule!
+    EventPaymentMethod::GoCardlessInstalments.create_schedule_for_order!(self)
+  rescue StandardError => e
+    ErrorReporting.capture_exception(e, context: { order_id: id.to_s, billing_request_id: gocardless_billing_request_id })
+    nil
   end
 
   def payment_completed!
@@ -267,7 +308,9 @@ class Order
 
   after_destroy :refund
   def refund
-    return unless event.refund_deleted_orders && !prevent_refund && event.organisation && value && value.positive? && payment_completed && (payment_intent || gocardless_payment_id)
+    return unless event.refund_deleted_orders && !prevent_refund && event.organisation && value && value.positive?
+    return unless payment_completed || (gocardless_instalments? && amount_paid.to_f.positive?)
+    return unless payment_intent || gocardless_payment_id || gocardless_instalment_schedule_id
 
     if payment_intent
       refund_via_stripe(
@@ -275,12 +318,46 @@ class Order
         on_error: ->(error) { notify_of_failed_refund(error) },
         refund_application_fee: application_fee_amount && application_fee_amount > 0
       )
+    elsif gocardless_instalments?
+      cancel_gocardless_instalment_schedule
+      refund_gocardless_instalment_payments
     else
       refund_via_gocardless(
         payment_id: gocardless_payment_id,
         amount: value,
         on_error: ->(error) { notify_of_failed_refund(error) }
       )
+    end
+  end
+
+  def cancel_gocardless_instalment_schedule
+    return if gocardless_instalment_schedule_id.blank?
+
+    client = GoCardlessPro::Client.new(access_token: event.organisation.gocardless_access_token)
+    client.instalment_schedules.cancel(gocardless_instalment_schedule_id)
+  rescue StandardError => e
+    ErrorReporting.capture_exception(e, context: { order_id: id.to_s, instalment_schedule_id: gocardless_instalment_schedule_id })
+  end
+
+  def refund_gocardless_instalment_payments
+    payment_ids = Array(gocardless_payment_ids).presence || Array(gocardless_payment_id)
+    return if payment_ids.blank?
+
+    client = GoCardlessPro::Client.new(access_token: event.organisation.gocardless_access_token)
+    payment_ids.each do |payment_id|
+      payment = client.payments.get(payment_id)
+      amount_remaining = payment.amount.to_i - payment.amount_refunded.to_i
+      next unless amount_remaining.positive?
+
+      client.refunds.create(
+        params: {
+          amount: amount_remaining,
+          total_amount_confirmation: payment.amount_refunded.to_i + amount_remaining,
+          links: { payment: payment_id }
+        }
+      )
+    rescue StandardError => e
+      notify_of_failed_refund(e)
     end
   end
 

--- a/tasks/tasks.rake
+++ b/tasks/tasks.rake
@@ -14,7 +14,8 @@ namespace :hourly do
     puts 'clean up old temp files'
     system('find /tmp -maxdepth 1 -type f -mmin +60 -delete 2>/dev/null')
     puts 'delete stale uncompleted orders'
-    Order.incomplete.and(:created_at.lt => 1.hour.ago).destroy_all
+    # Keep GoCardless instalment orders (billing request / schedule in progress)
+    Order.incomplete.and(:created_at.lt => 1.hour.ago).and(gocardless_billing_request_id: nil).destroy_all
     puts 'update paid up status for organisations with orders in the last hour'
     Organisation.and(:id.in => Event.and(:id.in => Order.complete.and(:created_at.gt => 1.hour.ago).pluck(:event_id)).pluck(:organisation_id)).each(&:update_paid_up_without_delay)
     puts 'update monthly contributions current month'

--- a/test/gocardless_instalments_test.rb
+++ b/test/gocardless_instalments_test.rb
@@ -1,0 +1,177 @@
+require File.expand_path("#{File.dirname(__FILE__)}/test_config.rb")
+require 'ostruct'
+
+class GoCardlessInstalmentsTest < ActiveSupport::TestCase
+  include Capybara::DSL
+
+  test 'split_amounts_in_pence divides evenly when possible' do
+    assert_equal [2500, 2500, 2500, 2500], EventPaymentMethod::GoCardlessInstalments.split_amounts_in_pence(100, 4)
+  end
+
+  test 'split_amounts_in_pence puts remainder on the last instalment' do
+    assert_equal [333, 333, 334], EventPaymentMethod::GoCardlessInstalments.split_amounts_in_pence(10, 3)
+  end
+
+  test 'gocardless_instalments payment method is available when enabled' do
+    account = FactoryBot.create(:account)
+    organisation = FactoryBot.create(
+      :organisation,
+      account: account,
+      gocardless_access_token: 'sandbox_token',
+      gocardless_endpoint_secret: 'whsec_test',
+      gocardless_instalments: true,
+      gocardless_instalment_count: 3
+    )
+    event = FactoryBot.create(:event, organisation: organisation, account: account, last_saved_by: account, currency: 'GBP')
+
+    pm = EventPaymentMethod.object('gocardless_instalments')
+    assert pm
+    assert pm.available?(event)
+  end
+
+  test 'gocardless_instalments payment method is unavailable when disabled' do
+    account = FactoryBot.create(:account)
+    organisation = FactoryBot.create(:organisation, account: account, gocardless_access_token: 'sandbox_token')
+    event = FactoryBot.create(:event, organisation: organisation, account: account, last_saved_by: account, currency: 'GBP')
+
+    refute EventPaymentMethod.object('gocardless_instalments').available?(event)
+  end
+
+  test 'organisation defaults instalment count and validates range' do
+    account = FactoryBot.create(:account)
+    organisation = FactoryBot.build(
+      :organisation,
+      account: account,
+      gocardless_access_token: 'sandbox_token',
+      gocardless_endpoint_secret: 'whsec_test',
+      gocardless_instalments: true,
+      gocardless_instalment_count: nil
+    )
+    assert organisation.valid?
+    assert_equal 3, organisation.gocardless_instalment_count
+
+    organisation.gocardless_instalment_count = 1
+    refute organisation.valid?
+    assert_includes organisation.errors[:gocardless_instalment_count], 'must be between 2 and 12'
+  end
+
+  test 'record_gocardless_instalment_payment! completes order when paid in full' do
+    account = FactoryBot.create(:account)
+    organisation = FactoryBot.create(:organisation, account: account)
+    event = FactoryBot.create(:event, organisation: organisation, account: account, last_saved_by: account, currency: 'GBP')
+    order = event.orders.create!(
+      account: account,
+      currency: 'GBP',
+      value: 30,
+      amount_demanded: 30,
+      amount_paid: 0,
+      instalment_count: 3,
+      gocardless_billing_request_id: 'BRQ123',
+      gocardless_instalment_schedule_id: 'IS123',
+      payment_completed: false,
+      original_description: 'Test order'
+    )
+    order.tickets.create!(event: event, account: account, price: 30, payment_completed: false)
+
+    notifications = []
+    order.stub :send_tickets, -> { notifications << :tickets } do
+      order.stub :create_order_notification, -> { notifications << :notification } do
+        order.record_gocardless_instalment_payment!(payment_id: 'PM1', amount_major: 10)
+        order.record_gocardless_instalment_payment!(payment_id: 'PM2', amount_major: 10)
+        refute order.reload.payment_completed?
+
+        order.record_gocardless_instalment_payment!(payment_id: 'PM3', amount_major: 10)
+      end
+    end
+
+    order.reload
+    assert order.payment_completed?
+    assert_equal 30, order.amount_paid
+    assert_equal %w[PM1 PM2 PM3], order.gocardless_payment_ids
+    assert_includes notifications, :tickets
+    assert_includes notifications, :notification
+    assert order.tickets.first.payment_completed?
+  end
+
+  test 'record_gocardless_instalment_payment! is idempotent for the same payment id' do
+    account = FactoryBot.create(:account)
+    organisation = FactoryBot.create(:organisation, account: account)
+    event = FactoryBot.create(:event, organisation: organisation, account: account, last_saved_by: account, currency: 'GBP')
+    order = event.orders.create!(
+      account: account,
+      currency: 'GBP',
+      value: 20,
+      amount_demanded: 20,
+      amount_paid: 0,
+      instalment_count: 2,
+      gocardless_billing_request_id: 'BRQ456',
+      gocardless_instalment_schedule_id: 'IS456',
+      payment_completed: false,
+      original_description: 'Test order'
+    )
+
+    order.record_gocardless_instalment_payment!(payment_id: 'PM1', amount_major: 10)
+    order.record_gocardless_instalment_payment!(payment_id: 'PM1', amount_major: 10)
+
+    assert_equal 10, order.reload.amount_paid
+    assert_equal %w[PM1], order.gocardless_payment_ids
+    refute order.payment_completed?
+  end
+
+  test 'create_schedule_for_order! stores mandate and schedule ids' do
+    account = FactoryBot.create(:account)
+    organisation = FactoryBot.create(
+      :organisation,
+      account: account,
+      gocardless_access_token: 'sandbox_token',
+      gocardless_instalment_count: 3
+    )
+    event = FactoryBot.create(:event, organisation: organisation, account: account, last_saved_by: account, currency: 'GBP')
+    order = event.orders.create!(
+      account: account,
+      currency: 'GBP',
+      value: 30,
+      amount_demanded: 30,
+      amount_paid: 0,
+      instalment_count: 3,
+      gocardless_billing_request_id: 'BRQ789',
+      payment_completed: false,
+      original_description: 'Festival tickets'
+    )
+
+    billing_request = OpenStruct.new(
+      links: OpenStruct.new(mandate_request_mandate: 'MD123'),
+      mandate_request: { 'links' => { 'mandate' => 'MD123' } }
+    )
+    mandate = OpenStruct.new(next_possible_charge_date: '2026-08-14')
+    schedule = OpenStruct.new(id: 'IS999')
+    captured_params = nil
+
+    client = Object.new
+    billing_requests = Object.new
+    mandates = Object.new
+    instalment_schedules = Object.new
+
+    billing_requests.define_singleton_method(:get) { |_id| billing_request }
+    mandates.define_singleton_method(:get) { |_id| mandate }
+    instalment_schedules.define_singleton_method(:create_with_schedule) do |options|
+      captured_params = options[:params]
+      schedule
+    end
+    client.define_singleton_method(:billing_requests) { billing_requests }
+    client.define_singleton_method(:mandates) { mandates }
+    client.define_singleton_method(:instalment_schedules) { instalment_schedules }
+
+    GoCardlessPro::Client.stub :new, client do
+      EventPaymentMethod::GoCardlessInstalments.create_schedule_for_order!(order)
+    end
+
+    order.reload
+    assert_equal 'MD123', order.gocardless_mandate_id
+    assert_equal 'IS999', order.gocardless_instalment_schedule_id
+    assert_equal 'GBP', captured_params[:currency]
+    assert_equal 3000, captured_params[:total_amount]
+    assert_equal [1000, 1000, 1000], captured_params[:instalments][:amounts]
+    assert_equal 'MD123', captured_params[:links][:mandate]
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a new **Pay in instalments** event payment method backed by GoCardless Instalment Schedules.

Buyers set up a Direct Debit mandate once; GoCardless collects equal monthly payments. Tickets are emailed only when the schedule has fully cleared (`instalment_schedules.completed`, with a paid≥demanded safety net).

## How it works
1. Org enables **GoCardless instalment schedules** and sets instalment count (2–12, default 3)
2. Checkout offers **Pay in instalments** alongside other methods
3. Billing Request Flow collects the mandate
4. On `billing_requests.fulfilled` (and on return URL), Dandelion creates a monthly instalment schedule
5. Confirmed instalment payments update `amount_paid`
6. On schedule completion → `payment_completed!` + `send_tickets`

## Also includes
- Incomplete instalment orders are excluded from the 1-hour stale-order cleanup
- Admin order/ticket UI shows instalment progress
- Refund/cancel path for instalment schedules
- Docs updates for events + organisations
- Unit tests in `test/gocardless_instalments_test.rb`

## Test plan
- [x] `foreman run -e .env.test bundle exec ruby -I test test/gocardless_instalments_test.rb` — 8 runs, 28 assertions, 0 failures
- [ ] Enable GC instalments on an org with access token + webhook secret
- [ ] Purchase with Pay in instalments; confirm mandate redirect and “plan active” messaging
- [ ] Confirm webhook creates schedule and later completes order / sends tickets
- [ ] Confirm incomplete instalment orders are not deleted after 1 hour
- [ ] Confirm existing Instant Bank Pay checkout still completes as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a2904cd-78f6-47a5-8d36-9fc009e5a095?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a2904cd-78f6-47a5-8d36-9fc009e5a095&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

