### PR TITLE
Require a session to edit ticketholders

### DIFF
--- a/app/controllers/events.rb
+++ b/app/controllers/events.rb
@@ -234,6 +234,7 @@ Dandelion::App.controller do
     halt 403 if @event.organisation.banned_emails_a.include?(@account.email)
 
     @order = create_order_with_tickets(params[:ticketForm], params[:detailsForm])
+    remember_ticketholder_edit!(@order)
     pm = if @order.total > 0
            EventPaymentMethod.object(params[:detailsForm][:payment_method].to_s)
          else

--- a/app/controllers/orders.rb
+++ b/app/controllers/orders.rb
@@ -32,6 +32,7 @@ Dandelion::App.controller do
   get '/events/:id/orders/:order_id/ticketholders/:ticket_id/name' do
     @event = Event.find(params[:id]) || not_found
     @order = @event.orders.complete.find(params[:order_id]) || not_found
+    require_ticketholder_edit!(@order)
     @ticket = @order.tickets.find(params[:ticket_id])
     partial :'events/ticketholder_name', locals: { ticket: @ticket }
   end
@@ -39,6 +40,7 @@ Dandelion::App.controller do
   post '/events/:id/orders/:order_id/ticketholders/:ticket_id/name' do
     @event = Event.find(params[:id]) || not_found
     @order = @event.orders.complete.find(params[:order_id]) || not_found
+    require_ticketholder_edit!(@order)
     @ticket = @order.tickets.find(params[:ticket_id]) || not_found
     @ticket.set(name: params[:name])
     200
@@ -47,6 +49,7 @@ Dandelion::App.controller do
   get '/events/:id/orders/:order_id/ticketholders/:ticket_id/email' do
     @event = Event.find(params[:id]) || not_found
     @order = @event.orders.complete.find(params[:order_id]) || not_found
+    require_ticketholder_edit!(@order)
     @ticket = @order.tickets.find(params[:ticket_id])
     partial :'events/ticketholder_email', locals: { ticket: @ticket, success: params[:success] }
   end
@@ -54,6 +57,7 @@ Dandelion::App.controller do
   post '/events/:id/orders/:order_id/ticketholders/:ticket_id/email' do
     @event = Event.find(params[:id]) || not_found
     @order = @event.orders.complete.find(params[:order_id]) || not_found
+    require_ticketholder_edit!(@order)
     @ticket = @order.tickets.find(params[:ticket_id]) || not_found
     previous_email = @ticket.email
     @ticket.email = params[:email]

--- a/app/helpers/access_control.rb
+++ b/app/helpers/access_control.rb
@@ -294,6 +294,25 @@ Dandelion::App.helpers do
     end
   end
 
+  def can_edit_ticketholders?(order = @order)
+    return false unless order
+    return true if current_account && order.account_id == current_account.id
+    return true if order.event && event_admin?(order.event)
+
+    Array(session[:ticketholder_order_ids]).include?(order.id.to_s)
+  end
+
+  def remember_ticketholder_edit!(order)
+    return unless order
+
+    ids = Array(session[:ticketholder_order_ids]).map(&:to_s)
+    session[:ticketholder_order_ids] = (ids + [order.id.to_s]).uniq
+  end
+
+  def require_ticketholder_edit!(order = @order)
+    halt 403 unless can_edit_ticketholders?(order)
+  end
+
   def sign_in_required!(notice: 'Please sign up or sign in to continue', redirect_url: '/accounts/new', notice_type: :notice)
     kick!(notice: notice, redirect_url: redirect_url, notice_type: notice_type) unless current_account
   end

--- a/app/views/docs/md/events.md
+++ b/app/views/docs/md/events.md
@@ -219,7 +219,7 @@ By default, only the person who placed the order receives the order confirmation
 
 ## Transferring tickets
 
-**Event attendees:** Log in to Dandelion, go to the event page, click 'Edit ticketholders' and enter the name and email address of the person you gifted/sold your ticket to.
+**Event attendees:** Log in to Dandelion, go to the event page, click 'Edit ticketholders' and enter the name and email address of the person you gifted/sold your ticket to. The link in your order confirmation email also signs you in so you can add those details.
 
 The original ticket PDF will still work, so you can simply forward it to the new ticketholder. If the event has **Send order confirmation to other ticketholders** enabled, they will also receive the order confirmation automatically. Otherwise, if it's important that the PDF is reissued under the new name, you can get in touch with the event organiser and ask them to 'Resend single ticket' following the instructions below.
 

--- a/app/views/emails/tickets.erb
+++ b/app/views/emails/tickets.erb
@@ -42,9 +42,9 @@
       <hr>
       <%= EmailHelper.replace_youtube_oembeds(event.organisation.extra_info_for_ticket_email) %>
     <% end %>
-    <% if !event.evergreen? && !event.recording? && event.organisation.show_ticketholder_link_in_ticket_emails %>
+    <% if !event.evergreen? && !event.recording? && event.organisation.show_ticketholder_link_in_ticket_emails && !(defined?(viewing_on_web) && viewing_on_web) %>
       <p>
-        <a href="<%=ENV['BASE_URI']%>/e/<%=event.slug%>?order_id=<%=order.id%>">Visit this page to add details of ticketholders.</a>
+        <a href="<%=ENV['BASE_URI']%>/e/<%=event.slug%>?order_id=<%=order.id%>&sign_in_token=%recipient.token%">Visit this page to add details of ticketholders.</a>
       </p>
     <% end %>
     <% if event.organisation&.affiliate_credit_percentage && account.persisted? %>

--- a/app/views/events/_success.erb
+++ b/app/views/events/_success.erb
@@ -27,6 +27,7 @@
 
 
       <% unless @event.evergreen? %>
+        <% if can_edit_ticketholders?(@order) %>
         <script>
           function showSavedTooltipAndSubmit(element) {
             // Create tooltip if it doesn't exist
@@ -79,6 +80,7 @@
           </div>
           <% } %>
         </div>
+        <% end %>
       <% end %>
 
       <% if @event.organisation&.affiliate_credit_percentage %>

--- a/test/ticketholder_edit_test.rb
+++ b/test/ticketholder_edit_test.rb
@@ -1,0 +1,142 @@
+require File.expand_path("#{File.dirname(__FILE__)}/test_config.rb")
+require 'rack/test'
+
+class TicketholderEditTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Padrino.application
+  end
+
+  # Rack::Test has no Capybara session; stub the screenshot helper that test_config teardown calls.
+  def save_screenshot(*); end
+
+  def setup
+    super
+    @organiser = FactoryBot.create(:account)
+    @organisation = FactoryBot.create(:organisation, account: @organiser)
+    @event = FactoryBot.create(:event, organisation: @organisation, account: @organiser, last_saved_by: @organiser, prices: [0])
+    @event.ticket_types.first.set(quantity: 10)
+    @buyer = FactoryBot.create(:account)
+    @order = @event.orders.create!(account: @buyer, currency: @event.currency, payment_completed: true)
+    @ticket = @order.tickets.create!(event: @event, account: @buyer, ticket_type: @event.ticket_types.first, price: 0)
+    @name_path = "/events/#{@event.id}/orders/#{@order.id}/ticketholders/#{@ticket.id}/name"
+    @email_path = "/events/#{@event.id}/orders/#{@order.id}/ticketholders/#{@ticket.id}/email"
+  end
+
+  def sign_in(account)
+    account.generate_sign_in_token!
+    get "/?sign_in_token=#{account.sign_in_token}"
+  end
+
+  def checkout_as_guest
+    post "/events/#{@event.id}/purchase",
+         detailsForm: {
+           account: { name: 'Guest Buyer', email: "guest-#{SecureRandom.hex(4)}@#{ENV['DOMAIN']}" }
+         },
+         ticketForm: {
+           quantities: { @event.ticket_types.first.id.to_s => 1 }
+         }
+    assert_equal 200, last_response.status, last_response.body
+    payload = JSON.parse(last_response.body)
+    order = @event.orders.find(payload['order_id'])
+    ticket = order.tickets.first
+    [order, ticket]
+  end
+
+  test 'guest cannot get or post ticketholder fields without a checkout session' do
+    get @name_path
+    assert_equal 403, last_response.status
+
+    post @name_path, name: 'Ada Lovelace'
+    assert_equal 403, last_response.status
+    assert_nil @ticket.reload.name
+  end
+
+  test 'guest can edit ticketholder details after checkout in the same browser' do
+    order, ticket = checkout_as_guest
+    name_path = "/events/#{@event.id}/orders/#{order.id}/ticketholders/#{ticket.id}/name"
+    email_path = "/events/#{@event.id}/orders/#{order.id}/ticketholders/#{ticket.id}/email"
+
+    get name_path
+    assert_equal 200, last_response.status
+
+    post name_path, name: 'Ada Lovelace'
+    assert_equal 200, last_response.status
+    assert_equal 'Ada Lovelace', ticket.reload.name
+
+    post email_path, email: 'ada@example.com'
+    assert_equal 200, last_response.status
+    assert_equal 'ada@example.com', ticket.reload.email
+  end
+
+  test 'guest checkout session does not grant access to another order' do
+    checkout_as_guest
+    post @name_path, name: 'Intruder'
+    assert_equal 403, last_response.status
+    assert_nil @ticket.reload.name
+  end
+
+  test 'purchaser can edit while signed in' do
+    sign_in(@buyer)
+    post @name_path, name: 'Buyer Name'
+    assert_equal 200, last_response.status
+    assert_equal 'Buyer Name', @ticket.reload.name
+  end
+
+  test 'event admin can edit while signed in' do
+    sign_in(@organiser)
+    post @name_path, name: 'Admin Name'
+    assert_equal 200, last_response.status
+    assert_equal 'Admin Name', @ticket.reload.name
+  end
+
+  test 'another signed-in account cannot edit' do
+    sign_in(FactoryBot.create(:account))
+    post @name_path, name: 'Stranger'
+    assert_equal 403, last_response.status
+    assert_nil @ticket.reload.name
+  end
+
+  test 'event page shows ticketholder forms after guest checkout' do
+    order, = checkout_as_guest
+    get "/e/#{@event.slug}", order_id: order.id
+    assert_equal 200, last_response.status
+    assert_includes last_response.body, '/ticketholders/'
+  end
+
+  test 'event page hides ticketholder forms for a guest with only the order id' do
+    get "/e/#{@event.slug}", order_id: @order.id
+    assert_equal 200, last_response.status
+    refute_includes last_response.body, '/ticketholders/'
+  end
+
+  test 'event page shows ticketholder forms for a signed-in purchaser' do
+    sign_in(@buyer)
+    get "/e/#{@event.slug}", order_id: @order.id
+    assert_equal 200, last_response.status
+    assert_includes last_response.body, '/ticketholders/'
+  end
+
+  test 'order confirmation page does not include a sign-in ticketholder link' do
+    @organisation.set(show_ticketholder_link_in_ticket_emails: true)
+    get "/orders/#{@order.id}"
+    assert_equal 200, last_response.status
+    refute_includes last_response.body, 'Visit this page to add details of ticketholders'
+  end
+
+  test 'ticket email includes a sign-in link for ticketholder details' do
+    @organisation.set(show_ticketholder_link_in_ticket_emails: true)
+    @event.reload
+    html = EmailHelper.render(
+      :tickets,
+      event: @event,
+      order: @order,
+      account: @buyer,
+      tickets_table: ''
+    )
+    assert_includes html, 'Visit this page to add details of ticketholders'
+    assert_includes html, "order_id=#{@order.id}"
+    assert_includes html, 'sign_in_token=%recipient.token%'
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Knowing an order id is still enough to view tickets. Changing a ticketholder name or email now needs one of:

- this browser just placed the order (remembered in the checkout session)
- the purchaser’s signed-in session
- an event admin session

The confirmation-email “add ticketholder details” link reuses the existing `sign_in_token` (and is not shown on the public `GET /orders/:id` page).

Replaces #220.

**To test:** complete a guest checkout and confirm you can still edit ticketholder name/email on the success page. Open `/e/:slug?order_id=…` without a session while signed out and confirm the edit fields are hidden and POSTs return 403. Sign in as the purchaser or event admin and confirm edits still work from “Edit ticketholders”. Open the confirmation email link and confirm it signs you in so you can edit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc48ea3c-3bcf-423f-9800-87ce242461a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc48ea3c-3bcf-423f-9800-87ce242461a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

