### PR TITLE
Remove border radius from bar charts

### DIFF
--- a/app/views/_chart.erb
+++ b/app/views/_chart.erb
@@ -69,13 +69,11 @@
           {
             backgroundColor: 'rgba(0, 175, 94, 1)',
             borderColor: 'rgba(0, 175, 94, 1)',
-            borderRadius: 4,
             data: <%== data.values.to_json %>
           },
           {
             backgroundColor: 'rgba(0, 175, 94, 0.5)',
             borderColor: 'rgba(0, 175, 94, 0.5)',
-            borderRadius: 4,
             data: <%== data.size.times.map { |i| i == data.size - 1 ? (defined?(projection) ? projection : nil) : nil }.to_json %>
           }
         ],

--- a/app/views/stats/_contributions_chart.erb
+++ b/app/views/stats/_contributions_chart.erb
@@ -28,7 +28,6 @@
         backgroundColor: breakdownColors[key] || 'rgba(0, 175, 94, 0.92)',
         borderColor: breakdownColors[key] || 'rgba(0, 175, 94, 1)',
         borderWidth: 1,
-        borderRadius: 4,
         data: breakdownValues[key],
         stack: 'contributions'
       };
@@ -40,7 +39,6 @@
       backgroundColor: 'rgba(0, 175, 94, 0.28)',
       borderColor: 'rgba(0, 175, 94, 0.45)',
       borderWidth: 1,
-      borderRadius: 4,
       data: projectionData,
       stack: 'contributions'
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes Chart.js `borderRadius` from bar chart datasets so bars render with square corners.

## Changes
- `app/views/_chart.erb`: drop `borderRadius: 4` from the shared monthly bar chart (used on `/stats/charts` and organisation stats)
- `app/views/stats/_contributions_chart.erb`: drop `borderRadius: 4` from contribution breakdown and projection bars

Chart.js 3.5.1 defaults to `0`, so bars are now square.

## Testing
Logged in as the seed admin and checked:
- `/stats/contributions` stacked bars
- `/o/test-organisation/stats` Followers bars

Pixel analysis of the Followers chart: the top row of each ~51px bar is fully filled (`left_inset=0`, `right_inset=0`). A 4px radius would cut the corners.

[Contributions bar chart with square corners](https://cursor.com/agents/bc-09f9d5c7-6b60-4a68-b384-851b5f3174a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontributions_bar_chart_square_corners.png)
[Followers bar chart with square corners](https://cursor.com/agents/bc-09f9d5c7-6b60-4a68-b384-851b5f3174a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffollowers_bar_chart_square_corners.png)
[bar_charts_square_corners_walkthrough.mp4](https://cursor.com/agents/bc-09f9d5c7-6b60-4a68-b384-851b5f3174a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbar_charts_square_corners_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f9d5c7-6b60-4a68-b384-851b5f3174a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f9d5c7-6b60-4a68-b384-851b5f3174a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

