### PR TITLE
Add user auth and event order/ticket tools to MCP

### DIFF
--- a/app/views/docs/md/mcp.md
+++ b/app/views/docs/md/mcp.md
@@ -7,8 +7,9 @@ Dandelion supports the [Model Context Protocol](https://modelcontextprotocol.io/
 - Get trending events
 - Get upcoming events for an organisation
 - Get the authenticated account (requires an API key)
+- Get completed orders and tickets for an event you admin (requires an API key)
 
-All access is read-only.
+All access is read-only. Email addresses are included only when you are allowed to view them.
 
 ## MCP endpoint
 
@@ -20,7 +21,7 @@ https://dandelion.events/mcp
 
 ## Authentication
 
-Public tools work without authentication. Authenticated tools, such as Get Me, require your API key as a Bearer token.
+Public tools work without authentication. Authenticated tools, such as Get Me, Get Event Orders and Get Event Tickets, require your API key as a Bearer token.
 
 You can find your API key on your [profile edit page](/accounts/edit).
 

--- a/app/views/docs/md/mcp.md
+++ b/app/views/docs/md/mcp.md
@@ -6,6 +6,7 @@ Dandelion supports the [Model Context Protocol](https://modelcontextprotocol.io/
 - Look up events, organisations, gatherings and accounts, by slug/username or ID
 - Get trending events
 - Get upcoming events for an organisation
+- Get the authenticated account (requires an API key)
 
 All access is read-only.
 
@@ -15,4 +16,23 @@ Add the Dandelion MCP server to your AI assistant's MCP configuration:
 
 ```
 https://dandelion.events/mcp
+```
+
+## Authentication
+
+Public tools work without authentication. Authenticated tools, such as Get Me, require your API key as a Bearer token.
+
+You can find your API key on your [profile edit page](/accounts/edit).
+
+```json
+{
+  "mcpServers": {
+    "dandelion": {
+      "url": "https://dandelion.events/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
 ```

--- a/lib/ai/mcp.rb
+++ b/lib/ai/mcp.rb
@@ -24,6 +24,9 @@ module Dandelion
       }
     }.freeze
 
+    AUTH_REQUIRED_MESSAGE = 'Authentication required. Provide your API key as a Bearer token.'
+    BEARER_PATTERN = /\ABearer\s+(\S+)\z/i
+
     def self.config_for(model_class)
       MODEL_CONFIGS[model_class.name]
     end
@@ -73,6 +76,53 @@ module Dandelion
       fields_proc = config[:search_fields] || config[:fields]
       result = events.map { |e| fields_proc.call(e) }
       ::MCP::Tool::Response.new([{ type: 'text', text: result.to_json }])
+    end
+
+    def self.account_from_request(rack_request)
+      header = rack_request.get_header('HTTP_AUTHORIZATION')
+      return nil if header.blank?
+
+      match = header.match(BEARER_PATTERN)
+      return :invalid unless match
+
+      Account.find_by(api_key: match[1]) || :invalid
+    end
+
+    def self.unauthorized_response
+      [
+        401,
+        {
+          'Content-Type' => 'application/json',
+          'WWW-Authenticate' => 'Bearer'
+        },
+        [{ error: 'invalid_token', error_description: 'Invalid API key' }.to_json]
+      ]
+    end
+
+    def self.current_account_from(server_context)
+      return unless server_context.respond_to?(:[])
+
+      server_context[:current_account]
+    end
+
+    def self.with_account(server_context)
+      account = current_account_from(server_context)
+      return yield(account) if account
+
+      ::MCP::Tool::Response.new([{ type: 'text', text: AUTH_REQUIRED_MESSAGE }], error: true)
+    end
+
+    def self.perform_get_me(server_context: nil)
+      with_account(server_context) do |account|
+        result = {
+          id: account.id.to_s,
+          name: account.name,
+          username: account.username,
+          email: account.email,
+          url: "#{ENV['BASE_URI']}/u/#{account.username}"
+        }
+        ::MCP::Tool::Response.new([{ type: 'text', text: result.to_json }])
+      end
     end
 
     def self.perform_get_upcoming_organisation_events(slug: nil, id: nil, from: nil, to: nil, limit: nil)
@@ -172,6 +222,16 @@ module Dandelion
           define_singleton_method(:call) do |limit: nil, _server_context: {}|
             Dandelion::MCP.perform_get_trending_events(limit: limit)
           end
+        end,
+        Class.new(::MCP::Tool) do
+          tool_name 'get_me_tool'
+          title 'Get Me'
+          description 'Get the authenticated Dandelion account. Requires a Bearer API key.'
+          annotations(read_only_hint: true, destructive_hint: false)
+
+          define_singleton_method(:call) do |server_context: {}|
+            Dandelion::MCP.perform_get_me(server_context: server_context)
+          end
         end
       ].freeze
     end
@@ -182,9 +242,17 @@ module Dandelion
           name: 'dandelion',
           title: 'Dandelion',
           version: '1.0.0',
-          instructions: 'Tools for querying Dandelion accounts, events, organisations and gatherings.',
+          instructions: 'Tools for querying Dandelion accounts, events, organisations and gatherings. Authenticated tools such as get_me_tool require a Bearer API key.',
           tools: tools
         )
+        def s.server_context
+          Thread.current[:mcp_server_context]
+        end
+
+        def s.server_context=(value)
+          Thread.current[:mcp_server_context] = value
+        end
+
         ::MCP::Server::Transports::StreamableHTTPTransport.new(
           s,
           stateless: true,
@@ -209,7 +277,13 @@ module Dandelion
     end
 
     def self.handle_http_request(rack_request)
+      account = account_from_request(rack_request)
+      return unauthorized_response if account == :invalid
+
+      server.server_context = { current_account: account }
       http_transport.handle_request(rack_request)
+    ensure
+      server.server_context = nil
     end
   end
 end

--- a/lib/ai/mcp.rb
+++ b/lib/ai/mcp.rb
@@ -105,23 +105,113 @@ module Dandelion
       server_context[:current_account]
     end
 
+    def self.tool_text(text, error: false)
+      ::MCP::Tool::Response.new([{ type: 'text', text: text }], error: error)
+    end
+
+    def self.tool_json(payload)
+      tool_text(payload.to_json)
+    end
+
+    def self.tool_error(message)
+      tool_text(message, error: true)
+    end
+
+    def self.clamp_limit(limit)
+      (limit || 20).to_i.clamp(1, 100)
+    end
+
     def self.with_account(server_context)
       account = current_account_from(server_context)
       return yield(account) if account
 
-      ::MCP::Tool::Response.new([{ type: 'text', text: AUTH_REQUIRED_MESSAGE }], error: true)
+      tool_error(AUTH_REQUIRED_MESSAGE)
+    end
+
+    def self.find_event(slug: nil, id: nil)
+      if id.present?
+        Event.unscoped.find(id)
+      elsif slug.present?
+        Event.unscoped.find_by(slug: slug)
+      end
+    end
+
+    def self.with_event_admin(server_context, slug: nil, id: nil)
+      with_account(server_context) do |account|
+        if slug.blank? && id.blank?
+          next tool_error('Provide event slug or id')
+        end
+
+        event = find_event(slug: slug, id: id)
+        next tool_error('Event not found') unless event
+        next tool_error('You do not have access to this event') unless Event.admin?(event, account)
+
+        yield(account, event)
+      end
     end
 
     def self.perform_get_me(server_context: nil)
       with_account(server_context) do |account|
-        result = {
+        tool_json(
           id: account.id.to_s,
           name: account.name,
           username: account.username,
           email: account.email,
           url: "#{ENV['BASE_URI']}/u/#{account.username}"
-        }
-        ::MCP::Tool::Response.new([{ type: 'text', text: result.to_json }])
+        )
+      end
+    end
+
+    def self.order_payload(order, account)
+      email_visible = Order.email_viewer?(order, account)
+      {
+        id: order.id.to_s,
+        name: order.account ? order.account.name : '',
+        firstname: order.account ? order.account.firstname : '',
+        lastname: order.account ? order.account.lastname : '',
+        email: email_visible && order.account ? order.account.email : '',
+        value: order.value,
+        currency: order.currency,
+        opt_in_organisation: order.opt_in_organisation,
+        opt_in_facilitator: order.opt_in_facilitator,
+        hear_about: order.hear_about,
+        via: order.via,
+        answers: order.answers,
+        created_at: order.created_at.iso8601
+      }
+    end
+
+    def self.ticket_payload(ticket, account)
+      email_visible = Ticket.email_viewer?(ticket, account)
+      {
+        id: ticket.id.to_s,
+        name: ticket.account ? ticket.account.name : '',
+        firstname: ticket.account ? ticket.account.firstname : '',
+        lastname: ticket.account ? ticket.account.lastname : '',
+        email: email_visible && ticket.account ? ticket.account.email : '',
+        ordered_for_name: ticket.name,
+        ordered_for_email: email_visible ? ticket.email : '',
+        ticket_type: ticket.ticket_type.try(:name),
+        price: ticket.discounted_price,
+        currency: ticket.currency,
+        checked_in: ticket.checked_in,
+        checked_in_at: ticket.checked_in_at&.iso8601,
+        order_id: ticket.order_id&.to_s,
+        created_at: ticket.created_at.iso8601
+      }
+    end
+
+    def self.perform_get_event_orders(server_context: nil, slug: nil, id: nil, limit: nil)
+      with_event_admin(server_context, slug: slug, id: id) do |account, event|
+        orders = event.orders.complete.includes(:account).order('created_at desc').limit(clamp_limit(limit))
+        tool_json(orders.map { |order| order_payload(order, account) })
+      end
+    end
+
+    def self.perform_get_event_tickets(server_context: nil, slug: nil, id: nil, limit: nil)
+      with_event_admin(server_context, slug: slug, id: id) do |account, event|
+        tickets = event.tickets.complete.includes(:account, :ticket_type, :order).order('created_at desc').limit(clamp_limit(limit))
+        tool_json(tickets.map { |ticket| ticket_payload(ticket, account) })
       end
     end
 
@@ -232,6 +322,36 @@ module Dandelion
           define_singleton_method(:call) do |server_context: {}|
             Dandelion::MCP.perform_get_me(server_context: server_context)
           end
+        end,
+        Class.new(::MCP::Tool) do
+          tool_name 'get_event_orders_tool'
+          title 'Get Event Orders'
+          description 'Get completed orders for a Dandelion event you admin, by slug or ID. Requires a Bearer API key.'
+          input_schema(properties: {
+                         slug: { type: 'string', description: 'Event slug' },
+                         id: { type: 'string', description: 'Event ID' },
+                         limit: { type: 'integer', description: 'Max results (default 20, max 100)' }
+                       })
+          annotations(read_only_hint: true, destructive_hint: false)
+
+          define_singleton_method(:call) do |slug: nil, id: nil, limit: nil, server_context: {}|
+            Dandelion::MCP.perform_get_event_orders(server_context: server_context, slug: slug, id: id, limit: limit)
+          end
+        end,
+        Class.new(::MCP::Tool) do
+          tool_name 'get_event_tickets_tool'
+          title 'Get Event Tickets'
+          description 'Get completed tickets for a Dandelion event you admin, by slug or ID. Requires a Bearer API key.'
+          input_schema(properties: {
+                         slug: { type: 'string', description: 'Event slug' },
+                         id: { type: 'string', description: 'Event ID' },
+                         limit: { type: 'integer', description: 'Max results (default 20, max 100)' }
+                       })
+          annotations(read_only_hint: true, destructive_hint: false)
+
+          define_singleton_method(:call) do |slug: nil, id: nil, limit: nil, server_context: {}|
+            Dandelion::MCP.perform_get_event_tickets(server_context: server_context, slug: slug, id: id, limit: limit)
+          end
         end
       ].freeze
     end
@@ -242,7 +362,7 @@ module Dandelion
           name: 'dandelion',
           title: 'Dandelion',
           version: '1.0.0',
-          instructions: 'Tools for querying Dandelion accounts, events, organisations and gatherings. Authenticated tools such as get_me_tool require a Bearer API key.',
+          instructions: 'Tools for querying Dandelion accounts, events, organisations and gatherings. Authenticated tools such as get_me_tool, get_event_orders_tool and get_event_tickets_tool require a Bearer API key.',
           tools: tools
         )
         def s.server_context

--- a/test/mcp_test.rb
+++ b/test/mcp_test.rb
@@ -190,7 +190,8 @@ class McpTest < ActiveSupport::TestCase
     facilitator = FactoryBot.create(:account)
     attendee = FactoryBot.create(:account, name: 'Hidden Email')
     organisation = FactoryBot.create(:organisation, account: org_owner)
-    event = FactoryBot.create(:event, organisation: organisation, account: facilitator, last_saved_by: facilitator, prices: [0], show_emails: false)
+    event = FactoryBot.create(:event, organisation: organisation, account: org_owner, last_saved_by: org_owner, prices: [0], show_emails: false)
+    event.event_facilitations.create!(account: facilitator)
     order = event.orders.create!(account: attendee, currency: event.currency, value: 0, payment_completed: true, original_description: 'MCP privacy test')
     event.tickets.create!(account: attendee, order: order, ticket_type: event.ticket_types.first, payment_completed: true)
     headers = { 'Authorization' => "Bearer #{facilitator.api_key}" }

--- a/test/mcp_test.rb
+++ b/test/mcp_test.rb
@@ -30,6 +30,28 @@ class McpTest < ActiveSupport::TestCase
     rpc.dig('result', 'content', 0, 'text')
   end
 
+  def create_event_with_order_and_ticket
+    admin = FactoryBot.create(:account)
+    attendee = FactoryBot.create(:account, name: 'Ada Lovelace')
+    organisation = FactoryBot.create(:organisation, account: admin)
+    event = FactoryBot.create(:event, organisation: organisation, account: admin, last_saved_by: admin, prices: [0])
+    order = event.orders.create!(
+      account: attendee,
+      currency: event.currency,
+      value: 0,
+      payment_completed: true,
+      original_description: 'MCP test order',
+      via: 'newsletter'
+    )
+    ticket = event.tickets.create!(
+      account: attendee,
+      order: order,
+      ticket_type: event.ticket_types.first,
+      payment_completed: true
+    )
+    [admin, attendee, event, order, ticket]
+  end
+
   test 'public tools remain available without authentication' do
     rpc = mcp_tool_call('get_trending_events_tool', arguments: { limit: 1 })
 
@@ -75,5 +97,110 @@ class McpTest < ActiveSupport::TestCase
     assert_equal 401, last_response.status
     assert_equal 'Bearer', last_response['WWW-Authenticate']
     assert_equal 'invalid_token', JSON.parse(last_response.body)['error']
+  end
+
+  test 'tools list includes event order and ticket tools' do
+    rpc = mcp_rpc('tools/list')
+    names = rpc.dig('result', 'tools').map { |tool| tool['name'] }
+
+    assert_includes names, 'get_event_orders_tool'
+    assert_includes names, 'get_event_tickets_tool'
+  end
+
+  test 'event order and ticket tools require authentication' do
+    %w[get_event_orders_tool get_event_tickets_tool].each do |name|
+      rpc = mcp_tool_call(name, arguments: { slug: 'example' })
+
+      assert_equal 200, last_response.status
+      assert rpc.dig('result', 'isError')
+      assert_includes tool_text(rpc), 'Authentication required'
+    end
+  end
+
+  test 'event admin can query orders and tickets' do
+    admin, attendee, event, order, ticket = create_event_with_order_and_ticket
+    headers = { 'Authorization' => "Bearer #{admin.api_key}" }
+
+    orders_rpc = mcp_tool_call('get_event_orders_tool', arguments: { slug: event.slug }, headers: headers)
+    orders = JSON.parse(tool_text(orders_rpc))
+
+    assert_equal 200, last_response.status
+    refute orders_rpc.dig('result', 'isError')
+    assert_equal 1, orders.length
+    assert_equal order.id.to_s, orders.first['id']
+    assert_equal attendee.name, orders.first['name']
+    assert_equal attendee.email, orders.first['email']
+    assert_equal 'newsletter', orders.first['via']
+
+    tickets_rpc = mcp_tool_call('get_event_tickets_tool', arguments: { id: event.id.to_s }, headers: headers)
+    tickets = JSON.parse(tool_text(tickets_rpc))
+
+    assert_equal 200, last_response.status
+    refute tickets_rpc.dig('result', 'isError')
+    assert_equal 1, tickets.length
+    assert_equal ticket.id.to_s, tickets.first['id']
+    assert_equal attendee.name, tickets.first['name']
+    assert_equal attendee.email, tickets.first['email']
+    assert_equal event.ticket_types.first.name, tickets.first['ticket_type']
+    assert_equal order.id.to_s, tickets.first['order_id']
+  end
+
+  test 'non-admin cannot query event orders or tickets' do
+    _admin, _attendee, event, = create_event_with_order_and_ticket
+    stranger = FactoryBot.create(:account)
+    headers = { 'Authorization' => "Bearer #{stranger.api_key}" }
+
+    %w[get_event_orders_tool get_event_tickets_tool].each do |name|
+      rpc = mcp_tool_call(name, arguments: { slug: event.slug }, headers: headers)
+
+      assert_equal 200, last_response.status
+      assert rpc.dig('result', 'isError')
+      assert_includes tool_text(rpc), 'You do not have access to this event'
+    end
+  end
+
+  test 'event order and ticket tools require an event slug or id' do
+    admin, = create_event_with_order_and_ticket
+    headers = { 'Authorization' => "Bearer #{admin.api_key}" }
+
+    %w[get_event_orders_tool get_event_tickets_tool].each do |name|
+      rpc = mcp_tool_call(name, headers: headers)
+
+      assert_equal 200, last_response.status
+      assert rpc.dig('result', 'isError')
+      assert_includes tool_text(rpc), 'Provide event slug or id'
+    end
+  end
+
+  test 'event order and ticket tools return not found for unknown events' do
+    admin, = create_event_with_order_and_ticket
+    headers = { 'Authorization' => "Bearer #{admin.api_key}" }
+
+    %w[get_event_orders_tool get_event_tickets_tool].each do |name|
+      rpc = mcp_tool_call(name, arguments: { slug: 'does-not-exist' }, headers: headers)
+
+      assert_equal 200, last_response.status
+      assert rpc.dig('result', 'isError')
+      assert_includes tool_text(rpc), 'Event not found'
+    end
+  end
+
+  test 'event order and ticket tools hide emails from event admins who cannot view them' do
+    org_owner = FactoryBot.create(:account)
+    facilitator = FactoryBot.create(:account)
+    attendee = FactoryBot.create(:account, name: 'Hidden Email')
+    organisation = FactoryBot.create(:organisation, account: org_owner)
+    event = FactoryBot.create(:event, organisation: organisation, account: facilitator, last_saved_by: facilitator, prices: [0], show_emails: false)
+    order = event.orders.create!(account: attendee, currency: event.currency, value: 0, payment_completed: true, original_description: 'MCP privacy test')
+    event.tickets.create!(account: attendee, order: order, ticket_type: event.ticket_types.first, payment_completed: true)
+    headers = { 'Authorization' => "Bearer #{facilitator.api_key}" }
+
+    orders = JSON.parse(tool_text(mcp_tool_call('get_event_orders_tool', arguments: { slug: event.slug }, headers: headers)))
+    tickets = JSON.parse(tool_text(mcp_tool_call('get_event_tickets_tool', arguments: { slug: event.slug }, headers: headers)))
+
+    assert_equal '', orders.first['email']
+    assert_equal attendee.name, orders.first['name']
+    assert_equal '', tickets.first['email']
+    assert_equal attendee.name, tickets.first['name']
   end
 end

--- a/test/mcp_test.rb
+++ b/test/mcp_test.rb
@@ -1,0 +1,79 @@
+require File.expand_path("#{File.dirname(__FILE__)}/test_config.rb")
+require 'rack/test'
+
+class McpTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Padrino.application
+  end
+
+  def save_screenshot(*); end
+
+  def mcp_post(body, headers: {})
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json, text/event-stream'
+    headers.each { |key, value| header key, value }
+    post '/mcp', body.to_json
+  end
+
+  def mcp_rpc(method, params: {}, headers: {}, id: 1)
+    mcp_post({ jsonrpc: '2.0', id: id, method: method, params: params }, headers: headers)
+    JSON.parse(last_response.body)
+  end
+
+  def mcp_tool_call(name, arguments: {}, headers: {})
+    mcp_rpc('tools/call', params: { name: name, arguments: arguments }, headers: headers)
+  end
+
+  def tool_text(rpc)
+    rpc.dig('result', 'content', 0, 'text')
+  end
+
+  test 'public tools remain available without authentication' do
+    rpc = mcp_tool_call('get_trending_events_tool', arguments: { limit: 1 })
+
+    assert_equal 200, last_response.status
+    assert rpc.dig('result', 'content')
+    refute rpc.dig('result', 'isError')
+  end
+
+  test 'tools list includes get_me_tool without authentication' do
+    rpc = mcp_rpc('tools/list')
+
+    assert_equal 200, last_response.status
+    names = rpc.dig('result', 'tools').map { |tool| tool['name'] }
+    assert_includes names, 'get_me_tool'
+  end
+
+  test 'get_me_tool requires authentication' do
+    rpc = mcp_tool_call('get_me_tool')
+
+    assert_equal 200, last_response.status
+    assert rpc.dig('result', 'isError')
+    assert_includes tool_text(rpc), 'Authentication required'
+  end
+
+  test 'get_me_tool returns the authenticated account' do
+    account = FactoryBot.create(:account)
+
+    rpc = mcp_tool_call('get_me_tool', headers: { 'Authorization' => "Bearer #{account.api_key}" })
+    payload = JSON.parse(tool_text(rpc))
+
+    assert_equal 200, last_response.status
+    refute rpc.dig('result', 'isError')
+    assert_equal account.id.to_s, payload['id']
+    assert_equal account.name, payload['name']
+    assert_equal account.username, payload['username']
+    assert_equal account.email, payload['email']
+    assert_equal "#{ENV['BASE_URI']}/u/#{account.username}", payload['url']
+  end
+
+  test 'invalid bearer token is rejected' do
+    mcp_tool_call('get_me_tool', headers: { 'Authorization' => 'Bearer not-a-real-key' })
+
+    assert_equal 401, last_response.status
+    assert_equal 'Bearer', last_response['WWW-Authenticate']
+    assert_equal 'invalid_token', JSON.parse(last_response.body)['error']
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public MCP tools stay unauthenticated. Requests can now send a Dandelion API key as a Bearer token so authenticated tools can act as that account.

Authenticated tools:

- `get_me_tool` returns the signed-in account
- `get_event_orders_tool` lists completed orders for an event the account admins
- `get_event_tickets_tool` lists completed tickets for an event the account admins

Email addresses follow the same visibility rules as the admin CSV exports. Invalid API keys are rejected with HTTP 401. Missing keys still work for public tools.

Docs: `/docs/mcp` covers the header and config snippet. API keys remain on the profile edit page.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2635a3f9-57cd-43f9-8e16-852101d6532b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2635a3f9-57cd-43f9-8e16-852101d6532b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

