### PR TITLE
Fall back to text search when Atlas Search times out

### DIFF
--- a/models/concerns/searchable.rb
+++ b/models/concerns/searchable.rb
@@ -4,6 +4,8 @@ module Searchable
   # Hard cap on vector-enhanced search; beyond this we run text-only Atlas Search instead.
   VECTOR_EMBEDDING_TIMEOUT_SECONDS = 1.0
   VECTOR_AGGREGATE_MAX_TIME_MS = 1_000
+  # Atlas Search (mongot) timeout. Distinct from MongoDB MaxTimeMSExpired (code 50).
+  MONGOT_TIMEOUT_CODE = 65_160
 
   APOSTROPHES = %w[' ’ ‘ ʼ ＇ ′ ´].freeze
   APOSTROPHE_VARIANTS = Regexp.union(APOSTROPHES)
@@ -166,7 +168,7 @@ module Searchable
                   .aggregate(fusion_stages + suffix_stages, max_time_ms: VECTOR_AGGREGATE_MAX_TIME_MS)
                   .to_a
               rescue Mongo::Error::OperationFailure => e
-                raise unless e.max_time_ms_expired?
+                raise unless atlas_search_timeout?(e)
 
                 text_fallback = true
                 collection.aggregate(text_stages + suffix_stages).to_a
@@ -202,6 +204,10 @@ module Searchable
 
     def search_fields
       raise NotImplementedError, "#{self} must implement search_fields class method"
+    end
+
+    def atlas_search_timeout?(error)
+      error.max_time_ms_expired? || error.code == MONGOT_TIMEOUT_CODE
     end
 
     def apostrophe_variants(query)

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -5,14 +5,21 @@ class SearchTest < ActiveSupport::TestCase
   include Rack::Test::Methods
 
   class CapturingCollection
-    attr_reader :pipelines
+    attr_reader :pipelines, :kwargs_list
 
-    def initialize
+    def initialize(error: nil)
       @pipelines = []
+      @kwargs_list = []
+      @error = error
+      @calls = 0
     end
 
-    def aggregate(pipeline, **_kwargs)
+    def aggregate(pipeline, **kwargs)
       @pipelines << pipeline
+      @kwargs_list << kwargs
+      @calls += 1
+      raise @error if @error && @calls == 1
+
       []
     end
   end
@@ -77,6 +84,18 @@ class SearchTest < ActiveSupport::TestCase
 
   def stringify_keys(hash)
     hash.transform_keys(&:to_s)
+  end
+
+  def operation_failure(code:, code_name:, message: 'operation exceeded time limit')
+    Mongo::Error::OperationFailure.new(message, nil, code: code, code_name: code_name)
+  end
+
+  def search_with_vector_stub(collection, query: 'Sound')
+    OpenRouter.stub(:embedding, [0.1, 0.2, 0.3]) do
+      Event.stub(:collection, collection) do
+        Event.search(query, Event.unscoped, regex_search: false, vector_weight: 0.5)
+      end
+    end
   end
 
   test 'full page search for events' do
@@ -260,5 +279,45 @@ class SearchTest < ActiveSupport::TestCase
 
     refute_includes equals_filters(filter), ['organisation_id', organisation_id]
     assert suffix_match.keys.map(&:to_s).include?('$or')
+  end
+
+  test 'falls back to text search when mongot times out' do
+    collection = CapturingCollection.new(
+      error: operation_failure(code: 65_160, code_name: 'Location65160', message: 'remote error from mongot: operation exceeded time limit')
+    )
+
+    results = search_with_vector_stub(collection)
+
+    assert_equal 2, collection.pipelines.length
+    assert collection.pipelines.first.first.key?(:$rankFusion)
+    assert collection.pipelines.last.first.key?(:$search)
+    assert_equal 1000, collection.kwargs_list.first[:max_time_ms]
+    assert_equal [], results
+  end
+
+  test 'falls back to text search when maxTimeMS expires' do
+    collection = CapturingCollection.new(
+      error: operation_failure(code: 50, code_name: 'MaxTimeMSExpired')
+    )
+
+    results = search_with_vector_stub(collection)
+
+    assert_equal 2, collection.pipelines.length
+    assert collection.pipelines.first.first.key?(:$rankFusion)
+    assert collection.pipelines.last.first.key?(:$search)
+    assert_equal [], results
+  end
+
+  test 'reraises unexpected atlas search operation failures' do
+    collection = CapturingCollection.new(
+      error: operation_failure(code: 96, code_name: 'OperationNotSupportedInTransaction')
+    )
+
+    error = assert_raises(Mongo::Error::OperationFailure) do
+      search_with_vector_stub(collection)
+    end
+
+    assert_equal 96, error.code
+    assert_equal 1, collection.pipelines.length
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the most recent unresolved production error, [DANDELION-3P](https://symbiota.sentry.io/issues/DANDELION-3P).

## Problem

`GET /search` with vector-enhanced event search (`$rankFusion` + `$vectorSearch` + `$search`) can hit Atlas Search's mongot timeout:

```
Mongo::Error::OperationFailure: [65160:Location65160]
remote error from mongot: operation exceeded time limit
```

Search already falls back to text-only Atlas Search when MongoDB `MaxTimeMSExpired` (code 50) is raised. Mongot returns a different code (`65160`), so the rescue re-raised and the page 500ed.

## Fix

Treat mongot `Location65160` as a search timeout, same as `maxTimeMS` expiry, and run the existing text-only fallback.

## Tests

`foreman run -e .env.test bundle exec ruby -I test test/search_test.rb`

22 runs, 67 assertions, 0 failures, 0 errors, 0 skips.

Added coverage for:

- mongot timeout (65160) falling back to `$search`
- `MaxTimeMSExpired` (50) still falling back
- unrelated `OperationFailure` codes still raising

Fixes DANDELION-3P

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7a1494b-ef3b-4401-82d1-cc0eb35c074e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7a1494b-ef3b-4401-82d1-cc0eb35c074e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

