### PR TITLE
Replace omniauth-ethereum with Sign-In with Ethereum (EIP-4361) via siwe-rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,8 @@ gem 'zstd-ruby'
 gem 'bcrypt'
 gem 'omniauth'
 gem 'omniauth-atproto'
-gem 'omniauth-ethereum', github: 'q9f/omniauth-ethereum.rb'
 gem 'omniauth-google-oauth2'
+gem 'siwe-rb', require: 'siwe'
 
 # Validation and testing
 gem 'better_html'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,14 +14,6 @@ GIT
       ttfunk (~> 1.8)
 
 GIT
-  remote: https://github.com/q9f/omniauth-ethereum.rb.git
-  revision: 0cc83f29f9ef1d002434f36fd40eed361a9cc830
-  specs:
-    omniauth-ethereum (0.2.1)
-      eth (~> 0.5)
-      omniauth (~> 2.1)
-
-GIT
   remote: https://github.com/stephenreid321/activate-admin.git
   revision: 528fc9341ef81b253dceceefb9127154135223ff
   specs:
@@ -83,9 +75,6 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (3.3.1)
-    bls12-381 (0.3.1)
-      bigdecimal
-      h2c (>= 0.2.1, < 0.3)
     bson (5.2.0)
     builder (3.3.0)
     capybara (3.40.0)
@@ -133,7 +122,6 @@ GEM
       dragonfly (~> 1.0)
       fog-aws
     drb (2.2.3)
-    ecdsa (1.2.0)
     email_address (0.2.8)
       base64
       simpleidn
@@ -146,17 +134,6 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
-    eth (0.5.17)
-      base64 (~> 0.1)
-      bigdecimal (~> 3.1)
-      bls12-381 (~> 0.3)
-      forwardable (~> 1.3)
-      httpx (~> 1.6)
-      keccak (~> 1.3)
-      konstructor (~> 1.0)
-      openssl (~> 3.3)
-      rbsecp256k1 (~> 6.0)
-      scrypt (~> 3.0)
     event_stream_parser (1.0.0)
     excon (1.5.0)
       logger
@@ -203,15 +180,12 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    forwardable (1.4.0)
     geocoder (1.8.6)
       base64 (>= 0.1.0)
       csv (>= 3.0.0)
     gocardless_pro (4.3.0)
       base64
       faraday (>= 2, < 3)
-    h2c (0.2.1)
-      ecdsa (~> 1.2.0)
     haikunator (1.1.1)
     hana (1.3.7)
     hashie (5.1.0)
@@ -220,7 +194,6 @@ GEM
       nokogiri (~> 1.5)
     htmlbeautifier (1.4.3)
     htmlentities (4.4.2)
-    http-2 (1.1.3)
     http (5.3.1)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -229,8 +202,6 @@ GEM
     http-cookie (1.1.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httpx (1.7.6)
-      http-2 (>= 1.1.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     icalendar (2.12.2)
@@ -258,7 +229,6 @@ GEM
     jwt (3.2.0)
       base64
     keccak (1.3.3)
-    konstructor (1.0.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     llhttp-ffi (0.5.1)
@@ -412,7 +382,6 @@ GEM
       json-api-vanilla (~> 1.0.1)
       rack
     pdf-core (0.10.0)
-    pkg-config (1.6.5)
     pp (0.6.3)
       prettyprint
     prawn-qrcode (0.5.2)
@@ -466,10 +435,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbsecp256k1 (6.0.0)
-      mini_portile2 (~> 2.8)
-      pkg-config (~> 1.5)
-      rubyzip (~> 2.3)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -508,7 +473,6 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
-    rubyzip (2.4.1)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -520,9 +484,6 @@ GEM
     sawyer (0.9.3)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    scrypt (3.1.0)
-      ffi-compiler (>= 1.0, < 2.0)
-      rake (~> 13)
     securerandom (0.4.1)
     sentry-delayed_job (6.5.0)
       delayed_job (>= 4.0)
@@ -539,6 +500,8 @@ GEM
       rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    siwe-rb (0.3.0)
+      keccak (~> 1.3)
     smart_properties (1.17.0)
     snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
@@ -630,7 +593,6 @@ DEPENDENCIES
   octokit
   omniauth
   omniauth-atproto
-  omniauth-ethereum!
   omniauth-google-oauth2
   padrino
   patreon
@@ -656,6 +618,7 @@ DEPENDENCIES
   sentry-delayed_job
   sentry-ruby
   sinatra
+  siwe-rb
   ssrf_filter
   stripe
   timezone

--- a/app/app.rb
+++ b/app/app.rb
@@ -21,7 +21,7 @@ module Dandelion
     use OmniAuth::Builder do
       provider :account
       provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], { image_size: 400 }
-      provider :ethereum, { custom_title: 'Sign in with Ethereum' }
+      provider :ethereum
       provider :atproto,
                "#{ENV['BASE_URI']}/atproto/oauth-client-metadata.json",
                nil,

--- a/app/assets/javascripts/sign_in_with_ethereum.js
+++ b/app/assets/javascripts/sign_in_with_ethereum.js
@@ -1,7 +1,40 @@
+/* global ethereum */
 $(function () {
   document.title = 'Sign in with Ethereum'
+  const hasWallet = typeof window.ethereum !== 'undefined'
+  const $heading = $('<h1 style="text-align: center; display: block !important" class="mt-5"></h1>')
+  $('form').before('<div style="height: 50vh; background-size: cover; background-position: center center; background-image: url(/images/ethereum.webp)"></div>', $heading)
+
+  if (!hasWallet) {
+    $heading.html('No wallet found.<br /><a style="color: #2E63EF" href="https://zerion.io/download">Install Zerion Wallet</a>')
+    return
+  }
+
+  $heading.text('Sign in with Ethereum')
+
+  const form = document.querySelector('form')
+  const template = document.getElementById('siwe_template')
+
+  function toHex (str) {
+    return '0x' + Array.from(new TextEncoder().encode(str), function (b) { return b.toString(16).padStart(2, '0') }).join('')
+  }
+
+  async function signIn () {
+    const accounts = await ethereum.request({ method: 'eth_requestAccounts' })
+    const address = accounts[0]
+    // The server-rendered EIP-4361 message carries a zero-address placeholder because it cannot know the wallet address in advance
+    const message = template.value.replace(template.dataset.placeholder, address)
+    const signature = await ethereum.request({ method: 'personal_sign', params: [toHex(message), address] })
+    document.getElementById('siwe_message').value = message
+    document.getElementById('siwe_signature').value = signature
+    form.submit()
+  }
+
+  $('button').on('click', function (e) {
+    e.preventDefault()
+    signIn().catch(function () {
+      $heading.html('Signature request was cancelled.<br /><a style="color: #2E63EF" href="javascript:;" onclick="$(\'button\').click()">Try again</a>')
+    })
+  })
   $('button').click()
-  let h1 = 'Sign in with Ethereum'
-  if (typeof window.ethereum == 'undefined') { h1 = 'No wallet found.<br /><a style="color: #2E63EF" href="https://zerion.io/download">Install Zerion Wallet</a>' }
-  $('form').before('<div style="height: 50vh; background-size: cover; background-position: center center; background-image: url(/images/ethereum.webp)"></div><h1 style="text-align: center; display: block !important" class="mt-5">' + h1 + '</h1>')
 })

--- a/app/controllers/auth.rb
+++ b/app/controllers/auth.rb
@@ -29,7 +29,7 @@ Dandelion::App.controller do
                   rescue StandardError
                     nil
                   end
-                  provider_uid ? ProviderLink.find_by(provider: @provider.display_name, provider_uid: provider_uid).try(:account) : nil
+                  ProviderLink.find_for(@provider.display_name, provider_uid).try(:account)
                 end
       if current_account && env['omniauth.auth']['provider'] != 'account' # already signed in; attempt to connect
         if account # someone's already connected

--- a/lib/auth/omniauth_ethereum.rb
+++ b/lib/auth/omniauth_ethereum.rb
@@ -1,0 +1,95 @@
+# Sign-In with Ethereum (EIP-4361) via siwe-rb.
+#
+# The request phase issues a single-use nonce (kept in the session) and renders an
+# EIP-4361 message template bound to this site's domain and callback URI. The browser
+# substitutes the wallet address, signs the message with personal_sign and POSTs the
+# message and signature back. The callback phase parses the message and verifies the
+# signature, domain, URI, chain ID, expiry and nonce, so a captured signature cannot be
+# replayed, redirected from another site, or used to link a wallet via CSRF.
+module OmniAuth
+  module Strategies
+    class Ethereum
+      include OmniAuth::Strategy
+
+      option :name, 'ethereum'
+      option :title, 'Sign in with Ethereum'
+      option :statement, 'Sign in to Dandelion with your Ethereum account.'
+      option :chain_id, 1
+      option :expiry, 5 * 60
+
+      SESSION_KEY = 'omniauth.siwe_nonce'.freeze
+      ADDRESS_PLACEHOLDER = '0x0000000000000000000000000000000000000000'.freeze
+
+      def request_phase
+        nonce = Siwe.generate_nonce
+        session[SESSION_KEY] = nonce
+
+        form = OmniAuth::Form.new(title: options.title, url: callback_path)
+        form.html(%(<span class="custom_title">#{h(options.title)}</span>))
+        form.html(%(<input type="hidden" id="siwe_template" name="siwe_template" value="#{h(message_template(nonce))}" data-placeholder="#{ADDRESS_PLACEHOLDER}" />))
+        form.html(%(<input type="hidden" id="siwe_message" name="siwe_message" />))
+        form.html(%(<input type="hidden" id="siwe_signature" name="siwe_signature" />))
+        form.button 'Sign In'
+        form.to_response
+      end
+
+      def callback_phase
+        # The nonce is consumed whatever happens, so a failed attempt can't be retried with the same message
+        nonce = session.delete(SESSION_KEY)
+        return fail!(:invalid_request) unless request.post?
+        return fail!(:missing_nonce) unless nonce
+
+        message = Siwe::Message.parse(request.params['siwe_message'].to_s)
+        message.verify!(
+          signature: request.params['siwe_signature'].to_s,
+          domain: domain,
+          nonce: nonce,
+          uri: callback_uri,
+          chain_id: options.chain_id
+        )
+        @address = Siwe::Util.checksum_address(message.address)
+        return fail!(:invalid_credentials) unless @address
+
+        super
+      rescue Siwe::Error => e
+        fail!(e.type, e)
+      end
+
+      uid { @address }
+
+      info { { 'nickname' => @address } }
+
+      private
+
+      def message_template(nonce)
+        now = Time.now.utc
+        Siwe::Message.new(
+          domain: domain,
+          address: ADDRESS_PLACEHOLDER,
+          statement: options.statement,
+          uri: callback_uri,
+          chain_id: options.chain_id,
+          nonce: nonce,
+          issued_at: now.iso8601,
+          expiration_time: (now + options.expiry).iso8601
+        ).prepare_message
+      end
+
+      def base_uri
+        @base_uri ||= URI(ENV['BASE_URI'] || full_host)
+      end
+
+      def domain
+        base_uri.port == base_uri.default_port ? base_uri.host : "#{base_uri.host}:#{base_uri.port}"
+      end
+
+      def callback_uri
+        "#{base_uri.scheme}://#{domain}#{callback_path}"
+      end
+
+      def h(str)
+        Rack::Utils.escape_html(str)
+      end
+    end
+  end
+end

--- a/models/provider_link.rb
+++ b/models/provider_link.rb
@@ -13,4 +13,14 @@ class ProviderLink
   validates_presence_of :provider, :provider_uid, :omniauth_hash
   validates_uniqueness_of :provider, scope: :account
   validates_uniqueness_of :provider_uid, scope: :provider
+
+  def self.find_for(provider, provider_uid)
+    return nil unless provider_uid
+
+    link = find_by(provider: provider, provider_uid: provider_uid)
+    return link if link || provider != 'Ethereum'
+
+    # Ethereum uids are now EIP-55 checksummed, but older links stored the address as the wallet reported it (usually lowercase)
+    find_by(provider: provider, provider_uid: /\A#{Regexp.escape(provider_uid)}\z/i)
+  end
 end

--- a/test/accounts_test.rb
+++ b/test/accounts_test.rb
@@ -379,7 +379,125 @@ class AccountsTest < ActiveSupport::TestCase
     assert_equal 0, created.provider_links.count
   end
 
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Sign-In with Ethereum (EIP-4361)
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  test 'siwe request phase renders a message bound to this site' do
+    clear_cookies
+    get '/auth/ethereum'
+    template = siwe_template_from(last_response)
+
+    assert_includes template, "127.0.0.1:#{ENV['PORT']} wants you to sign in with your Ethereum account:"
+    assert_includes template, "URI: #{ENV['BASE_URI']}/auth/ethereum/callback"
+    assert_match(/^Nonce: [A-Za-z0-9]{17}$/, template)
+    assert_includes template, 'Expiration Time:'
+  end
+
+  test 'siwe signs in an account whose wallet is linked, matching the address case-insensitively' do
+    key = OpenSSL::PKey::EC.generate('secp256k1')
+    address = siwe_address(key)
+    account = FactoryBot.create(:account)
+    account.provider_links.create!(provider: 'Ethereum', provider_uid: address.downcase, omniauth_hash: { 'uid' => address.downcase })
+
+    message, signature = siwe_start_and_sign(key)
+    post '/auth/ethereum/callback', siwe_message: message, siwe_signature: signature
+
+    assert last_response.redirect?
+    assert_equal '/', URI(last_response.location).path
+    assert_equal 1, account.reload.sign_ins.count
+  end
+
+  test 'siwe offers signup with a checksummed uid for an unknown wallet' do
+    key = OpenSSL::PKey::EC.generate('secp256k1')
+    message, signature = siwe_start_and_sign(key)
+    post '/auth/ethereum/callback', siwe_message: message, siwe_signature: signature
+
+    assert last_response.ok?
+    assert_includes last_response.body, "isn't yet connected to a Dandelion account"
+    assert_equal siwe_address(key), last_request.session['omniauth.auth']['uid']
+  end
+
+  test 'siwe rejects a replayed signature' do
+    key = OpenSSL::PKey::EC.generate('secp256k1')
+    message, signature = siwe_start_and_sign(key)
+    post '/auth/ethereum/callback', siwe_message: message, siwe_signature: signature
+    assert last_response.ok?
+
+    post '/auth/ethereum/callback', siwe_message: message, siwe_signature: signature
+    assert_siwe_failure 'missing_nonce'
+  end
+
+  test 'siwe rejects a callback via GET' do
+    key = OpenSSL::PKey::EC.generate('secp256k1')
+    message, signature = siwe_start_and_sign(key)
+    get '/auth/ethereum/callback', siwe_message: message, siwe_signature: signature
+    assert_siwe_failure 'invalid_request'
+
+    post '/auth/ethereum/callback', siwe_message: message, siwe_signature: signature
+    assert_siwe_failure 'missing_nonce'
+  end
+
+  test 'siwe rejects a message signed for a different nonce or domain' do
+    key = OpenSSL::PKey::EC.generate('secp256k1')
+    message, = siwe_start_and_sign(key)
+
+    forged = message.sub(/^Nonce: .*$/, "Nonce: #{Siwe.generate_nonce}")
+    post '/auth/ethereum/callback', siwe_message: forged, siwe_signature: siwe_sign(key, forged)
+    assert_siwe_failure 'nonce_mismatch'
+
+    message, = siwe_start_and_sign(key)
+    forged = message.sub(/\A[^ ]+/, 'evil.example')
+    post '/auth/ethereum/callback', siwe_message: forged, siwe_signature: siwe_sign(key, forged)
+    assert_siwe_failure 'domain_mismatch'
+  end
+
+  test 'siwe rejects a signature from a different wallet' do
+    key = OpenSSL::PKey::EC.generate('secp256k1')
+    other_key = OpenSSL::PKey::EC.generate('secp256k1')
+    message, = siwe_start_and_sign(key)
+    post '/auth/ethereum/callback', siwe_message: message, siwe_signature: siwe_sign(other_key, message)
+    assert_siwe_failure 'invalid_signature'
+  end
+
   private
+
+  def siwe_template_from(response)
+    assert response.ok?
+    match = response.body.match(/id="siwe_template" name="siwe_template" value="([^"]*)"/)
+    assert match, 'siwe_template input not found'
+    CGI.unescapeHTML(match[1])
+  end
+
+  def siwe_start_and_sign(key)
+    clear_cookies
+    get '/auth/ethereum'
+    message = siwe_template_from(last_response).sub(OmniAuth::Strategies::Ethereum::ADDRESS_PLACEHOLDER, siwe_address(key).downcase)
+    [message, siwe_sign(key, message)]
+  end
+
+  def siwe_address(key)
+    public_key = key.public_key.to_octet_string(:uncompressed)
+    Siwe::Crypto.checksum_address("0x#{Siwe::Crypto.keccak256(public_key.byteslice(1, 64)).byteslice(-20, 20).unpack1('H*')}")
+  end
+
+  def siwe_sign(key, message)
+    digest = Siwe::Crypto.eip191_hash(message)
+    r, s = OpenSSL::ASN1.decode(key.dsa_sign_asn1(digest)).value.map { |v| v.value.to_i }
+    address = siwe_address(key)
+    [27, 28].each do |v|
+      signature = "0x#{r.to_s(16).rjust(64, '0')}#{s.to_s(16).rjust(64, '0')}#{v.to_s(16)}"
+      return signature if Siwe::Crypto.recover_address(message, signature) == address
+    end
+    flunk 'could not produce a recoverable signature'
+  end
+
+  def assert_siwe_failure(reason)
+    assert last_response.redirect?, "expected a redirect to /auth/failure, got #{last_response.status}"
+    location = URI(last_response.location)
+    assert_equal '/auth/failure', location.path
+    assert_includes Rack::Utils.parse_query(location.query)['message'], reason
+  end
 
   def start_omniauth_signup
     clear_cookies


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `q9f/omniauth-ethereum.rb` strategy verified only that a wallet had signed `"Sign in with Ethereum <unix time>"` within a ±10 minute window. Nothing bound the signature to this site, to the browser session, or to a single use, so:

- a captured or phished signature could be replayed (first-party POST) to sign in as whichever account had that wallet linked;
- a logged-in user who opened a crafted `/auth/ethereum/callback?...` GET URL had the attacker's wallet linked to their account via `link_omniauth_provider`.

## What

- **Gemfile**: drop `omniauth-ethereum` (GitHub fork), add [`siwe-rb`](https://rubygems.org/gems/siwe-rb) 0.3.0 (EIP-4361 message construction/parsing/verification; depends only on `keccak`). Removing the old gem also removes `eth`, `rbsecp256k1`, and the `rubyzip 2.4.1` transitive dependency flagged by bundler-audit.
- **`lib/auth/omniauth_ethereum.rb`**: new `OmniAuth::Strategies::Ethereum`.
  - Request phase issues a session-stored nonce and renders an EIP-4361 message template bound to `BASE_URI`'s domain and the callback URI, with a 5-minute expiry.
  - Callback phase consumes the nonce on every attempt, requires POST, parses the message with `Siwe::Message.parse` and calls `verify!` with signature, domain, nonce, URI and chain ID. Any `Siwe::Error` becomes `fail!(error.type)`.
  - Provider name stays `ethereum` / display name `Ethereum`, so `/auth/ethereum` links, `Provider.object`, and existing `ProviderLink` rows keep working.
- **`app/assets/javascripts/sign_in_with_ethereum.js`**: requests the wallet address, substitutes it into the server-rendered message, `personal_sign`s it (hex-encoded), and POSTs message + signature. The gem's own JS, which rebuilt its own message, is gone.
- **`models/provider_link.rb`** / **`app/controllers/auth.rb`**: uids are now EIP-55 checksummed; `ProviderLink.find_for` falls back to a case-insensitive match for Ethereum so links stored with the wallet's original (usually lowercase) casing still sign in.
- **`test/accounts_test.rb`**: rack tests for the request-phase message, sign-in for a linked wallet, signup for an unknown wallet, and rejection of replay, GET callback, forged nonce/domain, and a signature from another wallet. Keys are generated and signed with OpenSSL's secp256k1 support, so tests need no `eth` gem.

## Verification

- `foreman run -e .env.test bundle exec ruby -I test test/accounts_test.rb`: **31 runs, 134 assertions, 0 failures, 0 errors** (7 new SIWE tests plus all existing sign-in/omniauth/merge tests).
- `bundle install` resolves cleanly; the app boots in the test environment and `OmniAuth::Strategies::Ethereum` / `Provider.object('ethereum')` resolve.
- Not verifiable here: real wallet interaction in the browser (`eth_requestAccounts` / `personal_sign`). Worth a manual check with MetaMask/Rabby on a dev deploy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4edb73a-6461-40d3-a616-55050746c7b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4edb73a-6461-40d3-a616-55050746c7b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

